### PR TITLE
[Parse] Changed Assert to AssertEq in Tests

### DIFF
--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -14,16 +14,16 @@ fn test_k4_n4_90nm_parse() {
     let res = res.unwrap();
 
     // Check tiles.
-    assert!(res.tiles.len() == 2);
-    assert!(res.tiles[0].name == "io");
-    assert!(res.tiles[1].name == "clb");
-    assert!(res.tiles[0].sub_tiles.len() == 1);
-    assert!(res.tiles[0].sub_tiles[0].name == "io");
-    assert!(res.tiles[0].sub_tiles[0].capacity == 3);
-    assert!(res.tiles[0].sub_tiles[0].equivalent_sites.len() == 1);
-    assert!(res.tiles[0].sub_tiles[0].equivalent_sites[0].pb_type == "io");
+    assert_eq!(res.tiles.len(), 2);
+    assert_eq!(res.tiles[0].name,"io");
+    assert_eq!(res.tiles[1].name,"clb");
+    assert_eq!(res.tiles[0].sub_tiles.len(), 1);
+    assert_eq!(res.tiles[0].sub_tiles[0].name, "io");
+    assert_eq!(res.tiles[0].sub_tiles[0].capacity, 3);
+    assert_eq!(res.tiles[0].sub_tiles[0].equivalent_sites.len(), 1);
+    assert_eq!(res.tiles[0].sub_tiles[0].equivalent_sites[0].pb_type, "io");
     assert!(matches!(res.tiles[0].sub_tiles[0].equivalent_sites[0].pin_mapping, TileSitePinMapping::Direct));
-    assert!(res.tiles[0].sub_tiles[0].ports.len() == 3);
+    assert_eq!(res.tiles[0].sub_tiles[0].ports.len(), 3);
     assert!(matches!(res.tiles[0].sub_tiles[0].ports[0], Port::Input { .. }));
     assert!(matches!(res.tiles[0].sub_tiles[0].ports[1], Port::Output { .. }));
     assert!(matches!(res.tiles[0].sub_tiles[0].ports[2], Port::Clock { .. }));
@@ -31,21 +31,21 @@ fn test_k4_n4_90nm_parse() {
     assert!(matches!(res.tiles[0].sub_tiles[0].fc.in_fc, SubTileIOFC::Frac { .. }));
     assert!(matches!(res.tiles[0].sub_tiles[0].fc.out_fc, SubTileIOFC::Frac { .. }));
     assert!(matches!(res.tiles[0].sub_tiles[0].pin_locations, SubTilePinLocations::Custom { .. }));
-    assert!(res.tiles[1].sub_tiles.len() == 1);
-    assert!(res.tiles[1].sub_tiles[0].name == "clb");
-    assert!(res.tiles[1].sub_tiles[0].capacity == 1);
-    assert!(res.tiles[1].sub_tiles[0].equivalent_sites.len() == 1);
-    assert!(res.tiles[1].sub_tiles[0].equivalent_sites[0].pb_type == "clb");
+    assert_eq!(res.tiles[1].sub_tiles.len(), 1);
+    assert_eq!(res.tiles[1].sub_tiles[0].name, "clb");
+    assert_eq!(res.tiles[1].sub_tiles[0].capacity, 1);
+    assert_eq!(res.tiles[1].sub_tiles[0].equivalent_sites.len(), 1);
+    assert_eq!(res.tiles[1].sub_tiles[0].equivalent_sites[0].pb_type, "clb");
     assert!(matches!(res.tiles[1].sub_tiles[0].equivalent_sites[0].pin_mapping, TileSitePinMapping::Direct));
     assert!(matches!(res.tiles[1].sub_tiles[0].pin_locations, SubTilePinLocations::Spread));
 
     // Check layouts.
-    assert!(res.layouts.len() == 1);
+    assert_eq!(res.layouts.len(), 1);
     assert!(matches!(res.layouts[0], Layout::AutoLayout { .. }));
     match &res.layouts[0] {
         Layout::AutoLayout( auto_layout ) => {
-            assert!(auto_layout.aspect_ratio == 1.0);
-            assert!(auto_layout.grid_locations.len() == 3);
+            assert_eq!(auto_layout.aspect_ratio, 1.0);
+            assert_eq!(auto_layout.grid_locations.len(), 3);
             assert!(matches!(auto_layout.grid_locations[0], GridLocation::Perimeter { .. }));
             assert!(matches!(auto_layout.grid_locations[1], GridLocation::Corners { .. }));
             assert!(matches!(auto_layout.grid_locations[2], GridLocation::Fill { .. }));
@@ -55,42 +55,42 @@ fn test_k4_n4_90nm_parse() {
     }
 
     // Check device.
-    assert!(res.device.r_min_w_nmos == 4_220.93);
-    assert!(res.device.r_min_w_pmos == 11_207.6);
+    assert_eq!(res.device.r_min_w_nmos, 4_220.93);
+    assert_eq!(res.device.r_min_w_pmos, 11_207.6);
     assert!(matches!(res.device.x_distr, ChanWDist::Uniform { .. }));
     assert!(matches!(res.device.y_distr, ChanWDist::Uniform { .. }));
     assert!(matches!(res.device.sb_type, SBType::Wilton));
-    assert!(res.device.sb_fs == Some(3));
-    assert!(res.device.input_switch_name == "ipin_cblock");
+    assert_eq!(res.device.sb_fs, Some(3));
+    assert_eq!(res.device.input_switch_name, "ipin_cblock");
 
     // Check segment list
-    assert!(res.segment_list.len() == 1);
-    assert!(res.segment_list[0].freq == 1.0);
-    assert!(res.segment_list[0].length == 1);
+    assert_eq!(res.segment_list.len(), 1);
+    assert_eq!(res.segment_list[0].freq, 1.0);
+    assert_eq!(res.segment_list[0].length, 1);
     assert!(matches!(res.segment_list[0].segment_type, SegmentType::Unidir));
-    assert!(res.segment_list[0].r_metal == 0.0);
-    assert!(res.segment_list[0].c_metal == 0.0);
+    assert_eq!(res.segment_list[0].r_metal, 0.0);
+    assert_eq!(res.segment_list[0].c_metal, 0.0);
 
     // Check complex block list.
-    assert!(res.complex_block_list.len() == 2);
-    assert!(res.complex_block_list[0].name == "io");
-    assert!(res.complex_block_list[0].num_pb == 1);
+    assert_eq!(res.complex_block_list.len(), 2);
+    assert_eq!(res.complex_block_list[0].name, "io");
+    assert_eq!(res.complex_block_list[0].num_pb, 1);
     assert!(res.complex_block_list[0].blif_model.is_none());
-    assert!(res.complex_block_list[0].ports.len() == 3);
+    assert_eq!(res.complex_block_list[0].ports.len(), 3);
     assert!(matches!(res.complex_block_list[0].ports[0], Port::Input { .. }));
     assert!(matches!(res.complex_block_list[0].ports[1], Port::Output { .. }));
     assert!(matches!(res.complex_block_list[0].ports[2], Port::Clock { .. }));
     // TODO: Add stronger tests for pb_type ports.
     assert!(res.complex_block_list[0].pb_types.is_empty());
-    assert!(res.complex_block_list[0].modes.len() == 2);
-    assert!(res.complex_block_list[0].modes[0].name == "inpad");
-    assert!(res.complex_block_list[0].modes[0].pb_types.len() == 1);
-    assert!(res.complex_block_list[0].modes[0].pb_types[0].name == "inpad");
+    assert_eq!(res.complex_block_list[0].modes.len(), 2);
+    assert_eq!(res.complex_block_list[0].modes[0].name, "inpad");
+    assert_eq!(res.complex_block_list[0].modes[0].pb_types.len(), 1);
+    assert_eq!(res.complex_block_list[0].modes[0].pb_types[0].name, "inpad");
     assert!(res.complex_block_list[0].modes[0].pb_types[0].blif_model.is_some());
-    assert!(res.complex_block_list[0].modes[1].name == "outpad");
-    assert!(res.complex_block_list[0].modes[1].pb_types.len() == 1);
+    assert_eq!(res.complex_block_list[0].modes[1].name, "outpad");
+    assert_eq!(res.complex_block_list[0].modes[1].pb_types.len(), 1);
     // TODO: Make these pb_type heirarchy checks more robust.
-    assert!(res.complex_block_list[1].name == "clb");
+    assert_eq!(res.complex_block_list[1].name, "clb");
 
     // TODO: Collect stats on the architecture and ensure they match what is
     //       expected.
@@ -108,14 +108,14 @@ fn test_vtr_flagship_parse() {
 
     // Check tiles
     let tiles = &res.tiles;
-    assert!(tiles.len() == 4);
+    assert_eq!(tiles.len(), 4);
 
     let io_tile = &tiles[0];
-    assert!(io_tile.name == "io");
-    assert!(io_tile.sub_tiles.len() == 1);
+    assert_eq!(io_tile.name, "io");
+    assert_eq!(io_tile.sub_tiles.len(), 1);
     let io_subtile = &io_tile.sub_tiles[0];
-    assert!(io_subtile.name == "io");
-    assert!(io_subtile.capacity == 8);
+    assert_eq!(io_subtile.name, "io");
+    assert_eq!(io_subtile.capacity, 8);
 
     // TODO: Add stronger tests for the tiles.
 }
@@ -131,5 +131,5 @@ fn test_stratix_iv_parse() {
     let res = res.unwrap();
 
     // Check tiles
-    assert!(res.tiles.len() == 6);
+    assert_eq!(res.tiles.len(), 6);
 }


### PR DESCRIPTION
Found that this is a bit more idiomatic and cleaner when things fail.