### PR TITLE
[Parse] Added Support for Timing Tags

### DIFF
--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -371,6 +371,44 @@ pub struct Segment {
     pub switch_points: SegmentSwitchPoints,
 }
 
+pub enum DelayType {
+    Max,
+    Min,
+}
+
+pub enum DelayInfo {
+    Constant {
+        min: f32,
+        max: f32,
+        in_port: String,
+        out_port: String,
+    },
+    Matrix {
+        delay_type: DelayType,
+        // This matrix is [in_pin_idx][out_pin_idx]
+        // TODO: The documentation should be more clear on this.
+        matrix: Vec<Vec<f32>>,
+        in_port: String,
+        out_port: String,
+    },
+}
+
+pub enum TimingConstraintType {
+    Hold,
+    Setup,
+    ClockToQ,
+}
+
+pub struct TimingConstraintInfo {
+    pub constraint_type: TimingConstraintType,
+    // NOTE: Only ClockToQ can have two different min/max values right now.
+    //       A bit of future proofing and cleanup to split max and min here.
+    pub min_value: f32,
+    pub max_value: f32,
+    pub port: String,
+    pub clock: String,
+}
+
 pub struct PackPattern {
     pub name: String,
     pub in_port: String,
@@ -385,6 +423,7 @@ pub struct CompleteInterconnect {
     //        may be a single pack pattern; however, an interconnect may have many
     //        pack patterns.
     pub pack_patterns: Vec<PackPattern>,
+    pub delays: Vec<DelayInfo>,
     pub metadata: Option<Vec<Metadata>>,
 }
 
@@ -393,6 +432,7 @@ pub struct DirectInterconnect {
     pub input: String,
     pub output: String,
     pub pack_patterns: Vec<PackPattern>,
+    pub delays: Vec<DelayInfo>,
     pub metadata: Option<Vec<Metadata>>,
 }
 
@@ -401,6 +441,7 @@ pub struct MuxInterconnect {
     pub input: String,
     pub output: String,
     pub pack_patterns: Vec<PackPattern>,
+    pub delays: Vec<DelayInfo>,
     pub metadata: Option<Vec<Metadata>>,
 }
 
@@ -433,6 +474,8 @@ pub struct PBType {
     pub modes: Vec<PBMode>,
     pub pb_types: Vec<PBType>,
     pub interconnects: Vec<Interconnect>,
+    pub delays: Vec<DelayInfo>,
+    pub timing_constraints: Vec<TimingConstraintInfo>,
     pub metadata: Option<Vec<Metadata>>,
 }
 

--- a/fpga_arch_parser/src/lib.rs
+++ b/fpga_arch_parser/src/lib.rs
@@ -16,12 +16,12 @@ mod parse_layouts;
 mod parse_device;
 mod parse_switch_list;
 mod parse_segment_list;
+mod parse_timing;
 mod parse_complex_block_list;
 
 pub use crate::parse_error::FPGAArchParseError;
 pub use crate::arch::*;
 
-use crate::parse_port::parse_port;
 use crate::parse_tiles::parse_tiles;
 use crate::parse_layouts::parse_layouts;
 use crate::parse_device::parse_device;

--- a/fpga_arch_parser/src/parse_tiles.rs
+++ b/fpga_arch_parser/src/parse_tiles.rs
@@ -9,7 +9,7 @@ use xml::attribute::OwnedAttribute;
 use crate::parse_error::*;
 use crate::arch::*;
 
-use crate::parse_port;
+use crate::parse_port::parse_port;
 
 fn parse_tile_site(name: &OwnedName,
                    attributes: &[OwnedAttribute],

--- a/fpga_arch_parser/src/parse_timing.rs
+++ b/fpga_arch_parser/src/parse_timing.rs
@@ -1,0 +1,399 @@
+use std::fs::File;
+use std::io::BufReader;
+
+use xml::common::Position;
+use xml::reader::{EventReader, XmlEvent};
+use xml::name::OwnedName;
+use xml::attribute::OwnedAttribute;
+
+use crate::parse_error::*;
+use crate::arch::*;
+
+pub fn parse_delay_constant(name: &OwnedName,
+                            attributes: &[OwnedAttribute],
+                            parser: &mut EventReader<BufReader<File>>) -> Result<DelayInfo, FPGAArchParseError> {
+    assert!(name.to_string() == "delay_constant");
+
+    let mut min: Option<f32> = None;
+    let mut max: Option<f32> = None;
+    let mut in_port: Option<String> = None;
+    let mut out_port: Option<String> = None;
+    for a in attributes {
+        match a.name.to_string().as_ref() {
+            "min" => {
+                min = match min {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "max" => {
+                max = match max {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "in_port" => {
+                in_port = match in_port {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "out_port" => {
+                out_port = match out_port {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            _ => return Err(FPGAArchParseError::UnknownAttribute(a.to_string(), parser.position())),
+        };
+    }
+    let in_port = match in_port {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("in_port".to_string(), parser.position())),
+    };
+    let out_port = match out_port {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("out_port".to_string(), parser.position())),
+    };
+    let (min, max) = match min {
+        Some(min) => match max {
+            Some(max) => (min, max),
+            None => (min, min),
+        },
+        None => match max {
+            Some(max) => (max, max),
+            None => return Err(FPGAArchParseError::MissingRequiredAttribute("At least one of the max or min attributes must be specified".to_string(), parser.position())),
+        },
+    };
+
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::StartElement { name, .. }) => {
+                return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position()));
+            },
+            Ok(XmlEvent::EndElement { name }) => {
+                match name.to_string().as_ref() {
+                    "delay_constant" => break,
+                    _ => return Err(FPGAArchParseError::UnexpectedEndTag(name.to_string(), parser.position())),
+                }
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(name.to_string()));
+            },
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(format!("{e:?}"), parser.position()));
+            },
+            _ => {},
+        };
+    }
+
+    Ok(DelayInfo::Constant {
+        min,
+        max,
+        in_port,
+        out_port,
+    })
+}
+
+fn parse_matrix_text(text: &str,
+                     parser: &EventReader<BufReader<File>>) -> Result<Vec<Vec<f32>>, FPGAArchParseError> {
+    let mut matrix: Vec<Vec<f32>> = Vec::new();
+
+    for line in text.split('\n') {
+        let mut matrix_row: Vec<f32> = Vec::new();
+        for v in line.split_whitespace() {
+            let element_val: f32 = match v.parse() {
+                Ok(val) => val,
+                Err(e) => return Err(FPGAArchParseError::InvalidTag(format!("Matrix text parse error: {e}"), parser.position())),
+            };
+            matrix_row.push(element_val);
+        }
+        matrix.push(matrix_row);
+    }
+
+    Ok(matrix)
+}
+
+pub fn parse_delay_matrix(name: &OwnedName,
+                          attributes: &[OwnedAttribute],
+                          parser: &mut EventReader<BufReader<File>>) -> Result<DelayInfo, FPGAArchParseError> {
+    assert!(name.to_string() == "delay_matrix");
+
+    let mut delay_type: Option<DelayType> = None;
+    let mut in_port: Option<String> = None;
+    let mut out_port: Option<String> = None;
+    for a in attributes {
+        match a.name.to_string().as_ref() {
+            "type" => {
+                delay_type = match delay_type {
+                    None => match a.value.as_ref() {
+                        "max" => Some(DelayType::Max),
+                        "min" => Some(DelayType::Min),
+                        _ => return Err(FPGAArchParseError::AttributeParseError(format!("Unknown delay type: {}", a.value), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                };
+            },
+            "in_port" => {
+                in_port = match in_port {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "out_port" => {
+                out_port = match out_port {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            _ => return Err(FPGAArchParseError::UnknownAttribute(a.to_string(), parser.position())),
+        };
+    }
+    let delay_type = match delay_type {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("type".to_string(), parser.position())),
+    };
+    let in_port = match in_port {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("in_port".to_string(), parser.position())),
+    };
+    let out_port = match out_port {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("out_port".to_string(), parser.position())),
+    };
+
+    let mut matrix: Option<Vec<Vec<f32>>> = None;
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::Characters(text)) => {
+                matrix = match matrix {
+                    None => Some(parse_matrix_text(&text, parser)?),
+                    Some(_) => return Err(FPGAArchParseError::InvalidTag("Duplicate characters within delay_matrix.".to_string(), parser.position())),
+                }
+            },
+            Ok(XmlEvent::EndElement { name: end_name }) => {
+                if end_name.to_string() == name.to_string() {
+                    break;
+                } else {
+                    return Err(FPGAArchParseError::UnexpectedEndTag(name.to_string(), parser.position()));
+                }
+            },
+            Ok(XmlEvent::StartElement { name, .. }) => {
+                return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position()));
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(name.to_string()));
+            },
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(format!("{e:?}"), parser.position()));
+            },
+            _ => {},
+        };
+    }
+    let matrix = match matrix {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::InvalidTag("delay_matrix tag must contain text representation of the matrix data".to_string(), parser.position())),
+    };
+
+    Ok(DelayInfo::Matrix {
+        delay_type,
+        matrix,
+        in_port,
+        out_port,
+    })
+}
+
+fn parse_setup_or_hold(name: &OwnedName,
+                       attributes: &[OwnedAttribute],
+                       constraint_type: TimingConstraintType,
+                       parser: &mut EventReader<BufReader<File>>) -> Result<TimingConstraintInfo, FPGAArchParseError> {
+    assert!(name.to_string() == "T_setup" || name.to_string() == "T_hold");
+
+    let mut value: Option<f32> = None;
+    let mut port: Option<String> = None;
+    let mut clock: Option<String> = None;
+    for a in attributes {
+        match a.name.to_string().as_ref() {
+            "value" => {
+                value = match value {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "port" => {
+                port = match port {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "clock" => {
+                clock = match clock {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            _ => return Err(FPGAArchParseError::UnknownAttribute(a.to_string(), parser.position())),
+        };
+    }
+    let value = match value {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("value".to_string(), parser.position())),
+    };
+    let port = match port {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("port".to_string(), parser.position())),
+    };
+    let clock = match clock {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("clock".to_string(), parser.position())),
+    };
+
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::StartElement { name, .. }) => {
+                return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position()));
+            },
+            Ok(XmlEvent::EndElement { name: end_name }) => {
+                if end_name.to_string() == name.to_string() {
+                    break;
+                } else {
+                    return Err(FPGAArchParseError::UnexpectedEndTag(name.to_string(), parser.position()));
+                }
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(name.to_string()));
+            },
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(format!("{e:?}"), parser.position()));
+            },
+            _ => {},
+        };
+    }
+
+    Ok(TimingConstraintInfo {
+        constraint_type,
+        min_value: value,
+        max_value: value,
+        port,
+        clock,
+    })
+}
+
+pub fn parse_t_setup(name: &OwnedName,
+                     attributes: &[OwnedAttribute],
+                     parser: &mut EventReader<BufReader<File>>) -> Result<TimingConstraintInfo, FPGAArchParseError> {
+    assert!(name.to_string() == "T_setup");
+
+    parse_setup_or_hold(name, attributes, TimingConstraintType::Setup, parser)
+}
+
+pub fn parse_t_hold(name: &OwnedName,
+                    attributes: &[OwnedAttribute],
+                    parser: &mut EventReader<BufReader<File>>) -> Result<TimingConstraintInfo, FPGAArchParseError> {
+    assert!(name.to_string() == "T_hold");
+
+    parse_setup_or_hold(name, attributes, TimingConstraintType::Hold, parser)
+}
+
+pub fn parse_clock_to_q(name: &OwnedName,
+                        attributes: &[OwnedAttribute],
+                        parser: &mut EventReader<BufReader<File>>) -> Result<TimingConstraintInfo, FPGAArchParseError> {
+    assert!(name.to_string() == "T_clock_to_Q");
+
+    let mut min: Option<f32> = None;
+    let mut max: Option<f32> = None;
+    let mut port: Option<String> = None;
+    let mut clock: Option<String> = None;
+    for a in attributes {
+        match a.name.to_string().as_ref() {
+            "min" => {
+                min = match min {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "max" => {
+                max = match max {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "port" => {
+                port = match port {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "clock" => {
+                clock = match clock {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            _ => return Err(FPGAArchParseError::UnknownAttribute(a.to_string(), parser.position())),
+        };
+    }
+    let (min_value, max_value) = match min {
+        Some(min) => match max {
+            Some(max) => (min, max),
+            None => (min, min),
+        },
+        None => match max {
+            Some(max) => (max, max),
+            None => return Err(FPGAArchParseError::MissingRequiredAttribute("At least one of the max or min attributes must be specified".to_string(), parser.position())),
+        },
+    };
+    let port = match port {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("port".to_string(), parser.position())),
+    };
+    let clock = match clock {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("clock".to_string(), parser.position())),
+    };
+
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::StartElement { name, .. }) => {
+                return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position()));
+            },
+            Ok(XmlEvent::EndElement { name: end_name }) => {
+                if end_name.to_string() == name.to_string() {
+                    break;
+                } else {
+                    return Err(FPGAArchParseError::UnexpectedEndTag(name.to_string(), parser.position()));
+                }
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(name.to_string()));
+            },
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(format!("{e:?}"), parser.position()));
+            },
+            _ => {},
+        };
+    }
+
+    Ok(TimingConstraintInfo {
+        constraint_type: TimingConstraintType::ClockToQ,
+        min_value,
+        max_value,
+        port,
+        clock,
+    })
+}

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -107,22 +107,25 @@ fn test_k4_n4_90nm_parse() -> Result<(), FPGAArchParseError> {
 
     // Check complex block list.
     assert_eq!(res.complex_block_list.len(), 2);
-    assert_eq!(res.complex_block_list[0].name, "io");
-    assert_eq!(res.complex_block_list[0].num_pb, 1);
-    assert!(res.complex_block_list[0].blif_model.is_none());
-    assert_eq!(res.complex_block_list[0].ports.len(), 3);
-    assert!(matches!(res.complex_block_list[0].ports[0], Port::Input { .. }));
-    assert!(matches!(res.complex_block_list[0].ports[1], Port::Output { .. }));
-    assert!(matches!(res.complex_block_list[0].ports[2], Port::Clock { .. }));
+    let clb0 = &res.complex_block_list[0];
+    assert_eq!(clb0.name, "io");
+    assert_eq!(clb0.num_pb, 1);
+    assert!(clb0.blif_model.is_none());
+    assert_eq!(clb0.ports.len(), 3);
+    assert!(matches!(clb0.ports[0], Port::Input { .. }));
+    assert!(matches!(clb0.ports[1], Port::Output { .. }));
+    assert!(matches!(clb0.ports[2], Port::Clock { .. }));
     // TODO: Add stronger tests for pb_type ports.
-    assert!(res.complex_block_list[0].pb_types.is_empty());
-    assert_eq!(res.complex_block_list[0].modes.len(), 2);
-    assert_eq!(res.complex_block_list[0].modes[0].name, "inpad");
-    assert_eq!(res.complex_block_list[0].modes[0].pb_types.len(), 1);
-    assert_eq!(res.complex_block_list[0].modes[0].pb_types[0].name, "inpad");
-    assert!(res.complex_block_list[0].modes[0].pb_types[0].blif_model.is_some());
-    assert_eq!(res.complex_block_list[0].modes[1].name, "outpad");
-    assert_eq!(res.complex_block_list[0].modes[1].pb_types.len(), 1);
+    assert!(clb0.pb_types.is_empty());
+    assert_eq!(clb0.modes.len(), 2);
+    let clb0_mode0 = &clb0.modes[0];
+    assert_eq!(clb0_mode0.name, "inpad");
+    assert_eq!(clb0_mode0.pb_types.len(), 1);
+    assert_eq!(clb0_mode0.pb_types[0].name, "inpad");
+    assert!(clb0_mode0.pb_types[0].blif_model.is_some());
+    assert_eq!(clb0_mode0.interconnects.len(), 1);
+    assert_eq!(clb0.modes[1].name, "outpad");
+    assert_eq!(clb0.modes[1].pb_types.len(), 1);
     // TODO: Make these pb_type heirarchy checks more robust.
     assert_eq!(res.complex_block_list[1].name, "clb");
 


### PR DESCRIPTION
The timing tags contain information on the delays and timing constraints within the PBs.