### PR TITLE
[Parse] Added Global Direct Support

### DIFF
--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -381,6 +381,18 @@ pub struct Segment {
     pub switch_points: SegmentSwitchPoints,
 }
 
+pub struct GlobalDirect {
+    pub name: String,
+    pub from_pin: String,
+    pub to_pin: String,
+    pub x_offset: i32,
+    pub y_offset: i32,
+    pub z_offset: i32,
+    pub switch_name: Option<String>,
+    pub from_side: Option<PinSide>,
+    pub to_side: Option<PinSide>,
+}
+
 pub enum DelayType {
     Max,
     Min,
@@ -496,5 +508,6 @@ pub struct FPGAArch {
     pub device: DeviceInfo,
     pub switch_list: Vec<Switch>,
     pub segment_list: Vec<Segment>,
+    pub direct_list: Vec<GlobalDirect>,
     pub complex_block_list: Vec<PBType>,
 }

--- a/fpga_arch_parser/src/parse_complex_block_list.rs
+++ b/fpga_arch_parser/src/parse_complex_block_list.rs
@@ -436,6 +436,7 @@ fn parse_pb_type(name: &OwnedName,
                         //        files.
                         //        Will skip for now without error so we can support
                         //        their arch files.
+                        // TODO: Print a warning.
                         let _ = parser.skip();
                     },
                     _ => return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position())),

--- a/fpga_arch_parser/src/parse_direct_list.rs
+++ b/fpga_arch_parser/src/parse_direct_list.rs
@@ -1,0 +1,201 @@
+use std::fs::File;
+use std::io::BufReader;
+
+use xml::common::Position;
+use xml::reader::{EventReader, XmlEvent};
+use xml::name::OwnedName;
+use xml::attribute::OwnedAttribute;
+
+use crate::parse_error::*;
+use crate::arch::*;
+
+fn parse_direct(tag_name: &OwnedName,
+                attributes: &[OwnedAttribute],
+                parser: &mut EventReader<BufReader<File>>) -> Result<GlobalDirect, FPGAArchParseError> {
+    assert!(tag_name.to_string() == "direct");
+
+    let mut name: Option<String> = None;
+    let mut from_pin: Option<String> = None;
+    let mut to_pin: Option<String> = None;
+    let mut x_offset: Option<i32> = None;
+    let mut y_offset: Option<i32> = None;
+    let mut z_offset: Option<i32> = None;
+    let mut switch_name: Option<String> = None;
+    let mut from_side: Option<PinSide> = None;
+    let mut to_side: Option<PinSide> = None;
+    for a in attributes {
+        match a.name.to_string().as_ref() {
+            "name" => {
+                name = match name {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "from_pin" => {
+                from_pin = match from_pin {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "to_pin" => {
+                to_pin = match to_pin {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "x_offset" => {
+                x_offset = match x_offset {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "y_offset" => {
+                y_offset = match y_offset {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "z_offset" => {
+                z_offset = match z_offset {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => return Err(FPGAArchParseError::AttributeParseError(format!("{a}: {e}"), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "switch_name" => {
+                switch_name = match switch_name {
+                    None => Some(a.value.clone()),
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "from_side" => {
+                from_side = match from_side {
+                    None => match a.value.as_ref() {
+                        "left" => Some(PinSide::Left),
+                        "right" => Some(PinSide::Right),
+                        "top" => Some(PinSide::Top),
+                        "bottom" => Some(PinSide::Bottom),
+                        _ => return Err(FPGAArchParseError::AttributeParseError(format!("Unknown side: {}", a.value), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            "to_side" => {
+                to_side = match to_side {
+                    None => match a.value.as_ref() {
+                        "left" => Some(PinSide::Left),
+                        "right" => Some(PinSide::Right),
+                        "top" => Some(PinSide::Top),
+                        "bottom" => Some(PinSide::Bottom),
+                        _ => return Err(FPGAArchParseError::AttributeParseError(format!("Unknown side: {}", a.value), parser.position())),
+                    },
+                    Some(_) => return Err(FPGAArchParseError::DuplicateAttribute(a.to_string(), parser.position())),
+                }
+            },
+            _ => return Err(FPGAArchParseError::UnknownAttribute(a.to_string(), parser.position())),
+        };
+    }
+    let name = match name {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("name".to_string(), parser.position())),
+    };
+    let from_pin = match from_pin {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("from_pin".to_string(), parser.position())),
+    };
+    let to_pin = match to_pin {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("to_pin".to_string(), parser.position())),
+    };
+    let x_offset = match x_offset {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("x_offset".to_string(), parser.position())),
+    };
+    let y_offset = match y_offset {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("y_offset".to_string(), parser.position())),
+    };
+    let z_offset = match z_offset {
+        Some(p) => p,
+        None => return Err(FPGAArchParseError::MissingRequiredAttribute("z_offset".to_string(), parser.position())),
+    };
+
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::StartElement { name, .. }) => {
+                return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position()));
+            },
+            Ok(XmlEvent::EndElement { name }) => {
+                match name.to_string().as_ref() {
+                    "direct" => break,
+                    _ => return Err(FPGAArchParseError::UnexpectedEndTag(name.to_string(), parser.position())),
+                }
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(name.to_string()));
+            },
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(format!("{e:?}"), parser.position()));
+            },
+            _ => {},
+        };
+    }
+
+    Ok(GlobalDirect {
+        name,
+        from_pin,
+        to_pin,
+        x_offset,
+        y_offset,
+        z_offset,
+        switch_name,
+        from_side,
+        to_side,
+    })
+}
+
+pub fn parse_direct_list(name: &OwnedName,
+                         attributes: &[OwnedAttribute],
+                         parser: &mut EventReader<BufReader<File>>) -> Result<Vec<GlobalDirect>, FPGAArchParseError> {
+    assert!(name.to_string() == "directlist");
+    if !attributes.is_empty() {
+        return Err(FPGAArchParseError::UnknownAttribute(String::from("Expected to be empty"), parser.position()));
+    }
+
+    let mut direct_list: Vec<GlobalDirect> = Vec::new();
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::StartElement { name, attributes, .. }) => {
+                match name.to_string().as_str() {
+                    "direct" => {
+                        direct_list.push(parse_direct(&name, &attributes, parser)?);
+                    },
+                    _ => return Err(FPGAArchParseError::InvalidTag(name.to_string(), parser.position())),
+                };
+            },
+            Ok(XmlEvent::EndElement { name }) => {
+                match name.to_string().as_str() {
+                    "directlist" => break,
+                    _ => return Err(FPGAArchParseError::UnexpectedEndTag(name.to_string(), parser.position())),
+                }
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(name.to_string()));
+            },
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(format!("{e:?}"), parser.position()));
+            },
+            _ => {},
+        }
+    };
+
+    Ok(direct_list)
+}

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -108,6 +108,9 @@ fn test_k4_n4_90nm_parse() -> Result<(), FPGAArchParseError> {
     assert_eq!(res.segment_list[0].r_metal, 0.0);
     assert_eq!(res.segment_list[0].c_metal, 0.0);
 
+    // Check direct list
+    assert_eq!(res.direct_list.len(), 0);
+
     // Check complex block list.
     assert_eq!(res.complex_block_list.len(), 2);
     let clb0 = &res.complex_block_list[0];
@@ -232,6 +235,19 @@ fn test_vtr_flagship_parse() -> Result<(), FPGAArchParseError> {
     let io_subtile = &io_tile.sub_tiles[0];
     assert_eq!(io_subtile.name, "io");
     assert_eq!(io_subtile.capacity, 8);
+
+    // Check direct list.
+    assert_eq!(res.direct_list.len(), 1);
+    let gdirect = &res.direct_list[0];
+    assert_eq!(gdirect.name, "adder_carry");
+    assert_eq!(gdirect.from_pin, "clb.cout");
+    assert_eq!(gdirect.to_pin, "clb.cin");
+    assert_eq!(gdirect.x_offset, 0);
+    assert_eq!(gdirect.y_offset, -1);
+    assert_eq!(gdirect.z_offset, 0);
+    assert!(gdirect.switch_name.is_none());
+    assert!(gdirect.from_side.is_none());
+    assert!(gdirect.to_side.is_none());
 
     // TODO: Add stronger tests for the tiles.
     Ok(())


### PR DESCRIPTION
A top-level tag called directlist is used to specify all of the direct connections on the global-level (between tiles).