### PR TITLE
[Viewer] Added Basic Zoom to Grid View

### DIFF
--- a/fpga_arch_viewer/src/grid_renderer.rs
+++ b/fpga_arch_viewer/src/grid_renderer.rs
@@ -15,8 +15,8 @@ pub fn render_grid(
 ) -> Option<String> {
     // Cell size is based on the available space
     let available_size = ui.available_size();
-    let cell_size = available_size.x.min(available_size.y) / grid.width.max(grid.height) as f32;
-    let cell_size = cell_size * zoom_factor;
+    let max_dim = grid.width.max(grid.height).max(1) as f32;
+    let cell_size = (available_size.x.min(available_size.y) / max_dim) * zoom_factor;
 
     let mut clicked_tile: Option<String> = None;
 
@@ -76,8 +76,8 @@ pub fn render_grid(
                                     egui::Stroke::new(2.0, outline_color),
                                 );
 
-                                // Only draw the text if the cell size is large enough.
-                                if cell_size > 50.0 {
+                                // Only draw the text if the tile is large enough.
+                                if rect.width() > 50.0 {
                                     // Draw tile name in center (uppercase)
                                     let tile_name_upper = pb_type.to_uppercase();
                                     let font_size = (cell_size * 0.2).min(tile_height * 0.15);

--- a/fpga_arch_viewer/src/grid_view.rs
+++ b/fpga_arch_viewer/src/grid_view.rs
@@ -28,14 +28,17 @@ impl Default for GridState {
 }
 
 impl GridState {
+    const MIN_ZOOM: f32 = 0.9;
+    const MAX_ZOOM: f32 = 10.0;
+
     /// Zoom in by multiplying the zoom factor
     pub fn zoom_in(&mut self, zoom_scale: f32) {
-        self.zoom_factor = (self.zoom_factor * zoom_scale).min(10.0).max(0.9);
+        self.zoom_factor = (self.zoom_factor * zoom_scale).min(Self::MAX_ZOOM).max(Self::MIN_ZOOM);
     }
 
     /// Zoom out by dividing the zoom factor
     pub fn zoom_out(&mut self, zoom_scale: f32) {
-        self.zoom_factor = (self.zoom_factor / zoom_scale).min(10.0).max(0.9);
+        self.zoom_factor = (self.zoom_factor / zoom_scale).min(Self::MAX_ZOOM).max(Self::MIN_ZOOM);
     }
 
     /// Reset zoom to 1.0
@@ -123,7 +126,7 @@ impl GridView {
             let grid = match layout {
                 fpga_arch_parser::Layout::AutoLayout(auto_layout) => {
                     self.grid_state.aspect_ratio = auto_layout.aspect_ratio;
-                    self.grid_state.grid_height = ((self.grid_state.grid_width as f32 / auto_layout.aspect_ratio) as usize).max(1);
+                    update_grid_height_from_width(&mut self.grid_state);
                     DeviceGrid::from_auto_layout_with_dimensions(
                         arch,
                         self.grid_state.grid_width,
@@ -153,10 +156,10 @@ impl GridView {
         next_view_mode: &mut ViewMode,
         ui: &mut egui::Ui
     ) {
-        // Handle zoom input (Ctrl+Cmd + scroll wheel or pinch gesture)
+        // Handle zoom input (Cmd + scroll wheel or pinch gesture)
         let input = ui.input(|i| {
             let scroll_delta = i.raw_scroll_delta.y;
-            let zoom_modifier = i.modifiers.ctrl && i.modifiers.command;
+            let zoom_modifier = i.modifiers.command;
             (scroll_delta, zoom_modifier)
         });
 


### PR DESCRIPTION
Updated the Grid view with basic zooming functionality. Currently it only zooms into the top-left corner; however in the future we may need to rethink how we are zooming within scroll areas (similar to the complex block view).

Resolves #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive zoom controls (buttons, reset) and keyboard/mouse shortcut support (Cmd + scroll)  
  * Support for trackpad pinch gestures to adjust zoom  
  * Display current zoom percentage in the controls panel  
  * Responsive grid scaling so cells resize dynamically with zoom and window size  
  * Tile labels now show only when tiles are large enough for readability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->