### PR TITLE
[CI] Merged Jobs and added cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,18 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
 
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
     - name: Run clippy
       run: cargo clippy --all-features --all-targets -- -D warnings
 
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
     - name: Check formatting
       run: cargo fmt --all -- --check


### PR DESCRIPTION
Since the CI run time was dominated by the build time, I decided to cache the build. This should only cache the libraries in the Cargo.lock file. I anticipate this will cause Clippy to become the new bottleneck, so I merged it with the build so they can share the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow by adding caching for Rust build artifacts to speed up build times and reduce redundant work.
  * Retained existing linting and formatting checks while enhancing build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->