### PR TITLE
[Grid] Fixed S10 Grid Layout Bugs

### DIFF
--- a/fpga_arch_viewer/src/grid.rs
+++ b/fpga_arch_viewer/src/grid.rs
@@ -122,7 +122,8 @@ impl DeviceGrid {
                 let check_row = row + dy;
                 let check_col = col + dx;
                 if check_row < self.height && check_col < self.width {
-                    max_priority = std::cmp::max(max_priority, self.grid_priorities[check_row][check_col]);
+                    max_priority =
+                        std::cmp::max(max_priority, self.grid_priorities[check_row][check_col]);
                 }
             }
         }
@@ -249,7 +250,12 @@ impl DeviceGrid {
                 if self.height > 1 {
                     let mut col = 0;
                     while col < self.width {
-                        if self.place_tile(self.height - 1, col, &perimeter.pb_type, perimeter.priority) {
+                        if self.place_tile(
+                            self.height - 1,
+                            col,
+                            &perimeter.pb_type,
+                            perimeter.priority,
+                        ) {
                             col += tile_width;
                         } else {
                             col += 1;
@@ -271,7 +277,12 @@ impl DeviceGrid {
                 if self.width > 1 {
                     let mut row = 0;
                     while row < self.height {
-                        if self.place_tile(row, self.width - 1, &perimeter.pb_type, perimeter.priority) {
+                        if self.place_tile(
+                            row,
+                            self.width - 1,
+                            &perimeter.pb_type,
+                            perimeter.priority,
+                        ) {
                             row += tile_height;
                         } else {
                             row += 1;


### PR DESCRIPTION
I found that the grids for the S10 architecture were not quite correct for some device sizes. After digging into it, I found that the way we were dealing with priorities was not correct. VPR cuts some corners in some weird ways in order to simplify the grid building code. There are rare corner cases which can be hit. We want this tool to be as faithful to VPR as possible, so I tried to replicate the behavior the best I can. The architectures we care about should not hit these special corner cases, so as long as we match VPR, we should be ok.

Resolves #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved grid tile placement logic to respect priority levels and prevent unintended overwrites during placement operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->