### PR TITLE
[Viewer] Added Dropped Files Support

### DIFF
--- a/fpga_arch_viewer/src/common_ui.rs
+++ b/fpga_arch_viewer/src/common_ui.rs
@@ -17,6 +17,7 @@ pub fn render_welcome_message(ui: &mut egui::Ui, view_mode: &ViewMode) {
                 ui.label("You can:");
                 ui.label("  • Use File > Open to load a VTR architecture file");
                 ui.label("  • Try File > Open Sample to explore sample architectures");
+                ui.label("  • Drag and drop an architecture file directly into the app");
                 ui.add_space(20.0);
                 ui.label(format!("Current mode: {:?}", view_mode));
             });

--- a/fpga_arch_viewer/src/viewer.rs
+++ b/fpga_arch_viewer/src/viewer.rs
@@ -1,6 +1,6 @@
 use eframe::egui;
 use fpga_arch_parser::{FPGAArch, FPGAArchParseError};
-use log::info;
+use log::{info, warn};
 use std::io::{BufRead, BufReader};
 
 #[cfg(target_arch = "wasm32")]
@@ -378,15 +378,31 @@ impl FpgaViewer {
                 dropped_files = i.raw.dropped_files.clone();
             }
         });
-        // Load the dropped files.
+        // The viewer can only display one architecture at a time, so load the
+        // first supported file and ignore the rest.
         for file in dropped_files {
-            // Note: if multiple files are passed in, we try to load all of them.
-            //       Eventually I would like this interface to pass multiple different
-            //       types of files at the same time.
             if let Some(file_path) = file.path {
-                self.load_architecture_file(file_path);
-            } else if let (Some(data), file_name) = (file.bytes, file.name) {
-                self.load_architecture_from_bytes(data.to_vec(), file_name);
+                let is_xml = file_path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("xml"));
+                if is_xml {
+                    self.load_architecture_file(file_path);
+                    break;
+                } else {
+                    warn!("Cannot open dropped filepath: {}", file_path.display());
+                }
+            } else if let Some(data) = file.bytes {
+                let is_xml = file
+                    .name
+                    .rsplit_once('.')
+                    .is_some_and(|(_, ext)| ext.eq_ignore_ascii_case("xml"));
+                if is_xml {
+                    self.load_architecture_from_bytes(data.to_vec(), file.name);
+                    break;
+                } else {
+                    warn!("Cannot open dropped file: {}", file.name);
+                }
             }
         }
     }


### PR DESCRIPTION
Added the ability to drop files directly into the app to load an architecture file. This is confirmed working on the web app, but I could not get it working on Linux. May work on Mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop file support: load architecture files by dropping them onto the app window.
  * Welcome message updated to prompt users to drag and drop files.

* **Bug Fixes**
  * Non-architecture (non-XML) drops are ignored and produce a warning instead of silent failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->