### PR TITLE
[PrimitiveView] Added PB-Type Delay Annotations

### DIFF
--- a/fpga_arch_viewer/src/primitive_view.rs
+++ b/fpga_arch_viewer/src/primitive_view.rs
@@ -854,6 +854,8 @@ impl PrimitiveView {
         // or from an external navigation action like the summary view buttons).
         if self.last_rendered_model_name.as_deref() != Some(&model.name) {
             self.zoom = None;
+            self.selected_pb_type_idx = None;
+            self.selected_timing_arc = None;
             self.last_rendered_model_name = Some(model.name.clone());
         }
 
@@ -1523,9 +1525,11 @@ fn collect_pb_types_for_model<'a>(
         collect_pb_types_for_model(child, model_name, path, results);
     }
     for mode in &pb_type.modes {
+        path.push(mode.name.clone());
         for child in &mode.pb_types {
             collect_pb_types_for_model(child, model_name, path, results);
         }
+        path.pop();
     }
     path.pop();
 }


### PR DESCRIPTION
The models only declare which timing arcs may exist in the primitive, the actual delay annotations come from the pb-types. Added the ability to display these delay annotations.

Resolves #139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combined "Setup & Hold" arc visualization and aggregated annotations
  * Clock-to-Q delay annotations added and used for timing arcs
  * Interactive timing markers with popups showing formatted delay/constraint info
  * PB-type usage list and selection to drive delay/context display
  * Combinational delay annotations and coloring, including missing-data highlighting

* **UI Changes**
  * "Hold Constraints" checkbox replaced with "Clock to Q"
  * Model selector display truncation and PB-type usage list added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->