### PR TITLE
[NoC] Added Mesh Parsing

### DIFF
--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -628,6 +628,7 @@ pub struct NoCRouterInfo {
     pub id: i32,
     pub position_x: f32,
     pub position_y: f32,
+    pub layer: usize,
     pub connections: Vec<i32>,
 }
 

--- a/fpga_arch_parser/src/parse_noc.rs
+++ b/fpga_arch_parser/src/parse_noc.rs
@@ -181,12 +181,328 @@ fn parse_router<R: BufRead>(
         };
     }
 
+    // FIXME: Currently VTR cannot specify an individual NoC router's layer;
+    //        however, the mesh topology can. There is a gap in the spec.
     Ok(NoCRouterInfo {
         id,
         position_x,
         position_y,
+        layer: 0,
         connections,
     })
+}
+
+fn parse_mesh<R: BufRead>(
+    tag_name: &OwnedName,
+    attributes: &[OwnedAttribute],
+    parser: &mut EventReader<R>,
+) -> Result<NoCTopologyInfo, FPGAArchParseError> {
+    assert!(tag_name.to_string() == "mesh");
+
+    let mut start_x: Option<f32> = None;
+    let mut end_x: Option<f32> = None;
+    let mut start_y: Option<f32> = None;
+    let mut end_y: Option<f32> = None;
+    let mut start_layer: Option<i32> = None;
+    let mut end_layer: Option<i32> = None;
+    let mut size: Option<i32> = None;
+
+    for a in attributes {
+        match a.name.to_string().as_ref() {
+            "startx" => {
+                start_x = match start_x {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            "endx" => {
+                end_x = match end_x {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            "starty" => {
+                start_y = match start_y {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            "endy" => {
+                end_y = match end_y {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            "startlayer" => {
+                start_layer = match start_layer {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            "endlayer" => {
+                end_layer = match end_layer {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            "size" => {
+                size = match size {
+                    None => match a.value.parse() {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Err(FPGAArchParseError::AttributeParseError(
+                                format!("{a}: {e}"),
+                                parser.position(),
+                            ));
+                        }
+                    },
+                    Some(_) => {
+                        return Err(FPGAArchParseError::DuplicateAttribute(
+                            a.to_string(),
+                            parser.position(),
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err(FPGAArchParseError::UnknownAttribute(
+                    a.to_string(),
+                    parser.position(),
+                ));
+            }
+        };
+    }
+
+    let start_x = match start_x {
+        Some(v) => v,
+        None => {
+            return Err(FPGAArchParseError::MissingRequiredAttribute(
+                "startx".to_string(),
+                parser.position(),
+            ));
+        }
+    };
+    let end_x = match end_x {
+        Some(v) => v,
+        None => {
+            return Err(FPGAArchParseError::MissingRequiredAttribute(
+                "endx".to_string(),
+                parser.position(),
+            ));
+        }
+    };
+    let start_y = match start_y {
+        Some(v) => v,
+        None => {
+            return Err(FPGAArchParseError::MissingRequiredAttribute(
+                "starty".to_string(),
+                parser.position(),
+            ));
+        }
+    };
+    let end_y = match end_y {
+        Some(v) => v,
+        None => {
+            return Err(FPGAArchParseError::MissingRequiredAttribute(
+                "endy".to_string(),
+                parser.position(),
+            ));
+        }
+    };
+    let start_layer = start_layer.unwrap_or(0);
+    let end_layer = end_layer.unwrap_or(0);
+    let size = match size {
+        Some(v) => v,
+        None => {
+            return Err(FPGAArchParseError::MissingRequiredAttribute(
+                "size".to_string(),
+                parser.position(),
+            ));
+        }
+    };
+
+    if size < 2 {
+        return Err(FPGAArchParseError::InvalidTag(
+            format!("NoC mesh size must be greater than 1, got {size}"),
+            parser.position(),
+        ));
+    }
+    if end_layer < start_layer {
+        return Err(FPGAArchParseError::InvalidTag(
+            format!("NoC mesh endlayer ({end_layer}) must be >= startlayer ({start_layer})"),
+            parser.position(),
+        ));
+    }
+    if start_layer < 0 {
+        return Err(FPGAArchParseError::InvalidTag(
+            format!("NoC mesh start_layer ({start_layer}) must be non-negative"),
+            parser.position(),
+        ));
+    }
+
+    // Consume the mesh end tag; the mesh element has no children.
+    loop {
+        match parser.next() {
+            Ok(XmlEvent::StartElement { name, .. }) => {
+                return Err(FPGAArchParseError::InvalidTag(
+                    name.to_string(),
+                    parser.position(),
+                ));
+            }
+            Ok(XmlEvent::EndElement { name }) => match name.to_string().as_ref() {
+                "mesh" => break,
+                _ => {
+                    return Err(FPGAArchParseError::UnexpectedEndTag(
+                        name.to_string(),
+                        parser.position(),
+                    ));
+                }
+            },
+            Ok(XmlEvent::EndDocument) => {
+                return Err(FPGAArchParseError::UnexpectedEndOfDocument(
+                    tag_name.to_string(),
+                ));
+            }
+            Err(e) => {
+                return Err(FPGAArchParseError::XMLParseError(
+                    format!("{e:?}"),
+                    parser.position(),
+                ));
+            }
+            _ => {}
+        };
+    }
+
+    // Generate the mesh topology. Router IDs start at 0 at the bottom-left
+    // corner of the first layer and increase in row-major order across layers.
+    let num_layers = (end_layer - start_layer + 1) as usize;
+    let size = size as usize;
+    let mut routers: Vec<NoCRouterInfo> = Vec::with_capacity(num_layers * size * size);
+
+    for layer in 0..num_layers {
+        for row in 0..size {
+            for col in 0..size {
+                let id = (layer * size * size + row * size + col) as i32;
+
+                let pos_x = start_x + col as f32 * (end_x - start_x) / (size - 1) as f32;
+                let pos_y = start_y + row as f32 * (end_y - start_y) / (size - 1) as f32;
+
+                let mut connections: Vec<i32> = Vec::new();
+                if col > 0 {
+                    // Left neighbour.
+                    connections.push((layer * size * size + row * size + (col - 1)) as i32);
+                }
+                if col < size - 1 {
+                    // Right neighbour.
+                    connections.push((layer * size * size + row * size + (col + 1)) as i32);
+                }
+                if row > 0 {
+                    // Below neighbour.
+                    connections.push((layer * size * size + (row - 1) * size + col) as i32);
+                }
+                if row < size - 1 {
+                    // Above neighbour.
+                    connections.push((layer * size * size + (row + 1) * size + col) as i32);
+                }
+                if layer > 0 {
+                    // Neighbour on layer below.
+                    connections.push(((layer - 1) * size * size + row * size + col) as i32);
+                }
+                if layer < num_layers - 1 {
+                    // Neighbour on layer above.
+                    connections.push(((layer + 1) * size * size + row * size + col) as i32);
+                }
+
+                routers.push(NoCRouterInfo {
+                    id,
+                    position_x: pos_x,
+                    position_y: pos_y,
+                    layer: start_layer as usize + layer,
+                    connections,
+                });
+            }
+        }
+    }
+
+    Ok(NoCTopologyInfo { routers })
 }
 
 fn parse_topology<R: BufRead>(
@@ -421,6 +737,17 @@ pub fn parse_noc<R: BufRead>(
                         }
                     }
                 }
+                "mesh" => {
+                    topology = match topology {
+                        None => Some(parse_mesh(&child_name, &child_attributes, parser)?),
+                        Some(_) => {
+                            return Err(FPGAArchParseError::DuplicateTag(
+                                format!("<{child_name}>"),
+                                parser.position(),
+                            ));
+                        }
+                    }
+                }
                 _ => {
                     return Err(FPGAArchParseError::InvalidTag(
                         child_name.to_string(),
@@ -456,7 +783,7 @@ pub fn parse_noc<R: BufRead>(
         Some(t) => t,
         None => {
             return Err(FPGAArchParseError::MissingRequiredTag(
-                "<topology>".to_string(),
+                "<topology> or <mesh>".to_string(),
             ));
         }
     };

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -629,6 +629,59 @@ fn test_3d_k4_n4_90nm_opin_per_block() -> Result<(), FPGAArchParseError> {
 }
 
 #[test]
+fn mesh_noc_topology() -> Result<(), FPGAArchParseError> {
+    let input_xml_relative =
+        PathBuf::from("tests/k6_frac_N10_frac_chain_mem32K_40nm_with_a_2x2_mesh_noc_topology.xml");
+    let input_xml = absolute(&input_xml_relative).expect("Failed to get absolute path");
+
+    let res = fpga_arch_parser::parse(&input_xml)?;
+
+    // Check NoC info.
+    let noc = res.noc.as_ref().expect("Expected NoC info to be present");
+    assert_eq!(noc.link_latency, 1e-9);
+    assert_eq!(noc.router_latency, 2e-9);
+    assert_eq!(noc.link_bandwidth, 1.2e9);
+    assert_eq!(noc.noc_router_tile_name, "noc_router");
+
+    // A 2x2 single-layer mesh produces 4 routers.
+    // IDs are assigned row-major from the bottom-left corner:
+    //   id=0 (row=0,col=0)  id=1 (row=0,col=1)
+    //   id=2 (row=1,col=0)  id=3 (row=1,col=1)
+    let routers = &noc.topology.routers;
+    assert_eq!(routers.len(), 4);
+
+    // Bottom-left: connected to right (1) and above (2).
+    assert_eq!(routers[0].id, 0);
+    assert_eq!(routers[0].position_x, 0.0);
+    assert_eq!(routers[0].position_y, 0.0);
+    assert_eq!(routers[0].layer, 0);
+    assert_eq!(routers[0].connections, vec![1, 2]);
+
+    // Bottom-right: connected to left (0) and above (3).
+    assert_eq!(routers[1].id, 1);
+    assert_eq!(routers[1].position_x, 5.0);
+    assert_eq!(routers[1].position_y, 0.0);
+    assert_eq!(routers[1].layer, 0);
+    assert_eq!(routers[1].connections, vec![0, 3]);
+
+    // Top-left: connected to right (3) and below (0).
+    assert_eq!(routers[2].id, 2);
+    assert_eq!(routers[2].position_x, 0.0);
+    assert_eq!(routers[2].position_y, 5.0);
+    assert_eq!(routers[2].layer, 0);
+    assert_eq!(routers[2].connections, vec![3, 0]);
+
+    // Top-right: connected to left (2) and below (1).
+    assert_eq!(routers[3].id, 3);
+    assert_eq!(routers[3].position_x, 5.0);
+    assert_eq!(routers[3].position_y, 5.0);
+    assert_eq!(routers[3].layer, 0);
+    assert_eq!(routers[3].connections, vec![2, 1]);
+
+    Ok(())
+}
+
+#[test]
 fn embedded_star_noc_topology() -> Result<(), FPGAArchParseError> {
     let input_xml_relative = PathBuf::from(
         "tests/k6_frac_N10_frac_chain_mem32K_40nm_with_a_embedded_star_noc_topology.xml",
@@ -663,6 +716,7 @@ fn embedded_star_noc_topology() -> Result<(), FPGAArchParseError> {
         assert_eq!(routers[i].id, *id);
         assert_eq!(routers[i].position_x, *pos_x);
         assert_eq!(routers[i].position_y, *pos_y);
+        assert_eq!(routers[i].layer, 0);
         assert_eq!(routers[i].connections, vec![9]);
     }
 
@@ -671,6 +725,7 @@ fn embedded_star_noc_topology() -> Result<(), FPGAArchParseError> {
     assert_eq!(center.id, 9);
     assert_eq!(center.position_x, 16.5);
     assert_eq!(center.position_y, 10.5);
+    assert_eq!(center.layer, 0);
     assert_eq!(center.connections, vec![1, 2, 3, 4, 5, 6, 7, 8]);
 
     Ok(())

--- a/fpga_arch_parser/tests/k6_frac_N10_frac_chain_mem32K_40nm_with_a_2x2_mesh_noc_topology.xml
+++ b/fpga_arch_parser/tests/k6_frac_N10_frac_chain_mem32K_40nm_with_a_2x2_mesh_noc_topology.xml
@@ -1,0 +1,1639 @@
+<!-- 
+  Flagship Heterogeneous Architecture with Carry Chains for VTR 7.0.
+
+  - 40 nm technology
+  - General purpose logic block: 
+    K = 6, N = 10, fracturable 6 LUTs (can operate as one 6-LUT or two 5-LUTs with all 5 inputs shared) 
+    with optionally registered outputs
+    Each 5-LUT has an arithemtic mode that converts it to a single-bit adder with both inputs driven by 4-LUTs (both 4-LUTs share all 4 inputs)
+    Carry chain links to vertically adjacent logic blocks
+  - Memory size 32 Kbits, memory aspect ratios vary from a data width of 1 to data width of 64.  
+    Height = 6, found on every (8n+2)th column
+  - Multiplier modes: one 36x36, two 18x18, each 18x18 can also operate as two 9x9.  
+    Height = 4, found on every (8n+6)th column
+  - Routing architecture: L = 4, fc_in = 0.15, Fc_out = 0.1
+
+  Details on Modelling:
+
+  The electrical design of the architecture described here is NOT from an 
+  optimized, SPICED architecture.  Instead, we attempt to create a reasonable 
+  architecture file by using an existing commercial FPGA to approximate the area, 
+  delay, and power of the underlying components. This is combined with a reasonable 40 nm 
+  model of wiring and circuit design for low-level routing components, where available.
+  The resulting architecture has delays that roughly match a commercial 40 nm FPGA, but also 
+  has wiring electrical parameters that allow the wire lengths and switch patterns to be 
+  modified and you will still get reasonable delay results for the new architecture.
+  The following describes, in detail, how we obtained the various electrical values for this 
+  architecture.
+
+  Rmin for nmos and pmos, routing buffer sizes, and I/O pad delays are from the ifar 
+  architecture created by Ian Kuon: K06 N10 45nm fc 0.15 area-delay optimized architecture. 
+  (n10k06l04.fc15.area1delay1.cmos45nm.bptm.cmos45nm.xml)      
+  This routing architecture was optimized for 45 nm, and we have scaled it linearly to 40 nm to 
+  match the overall target (a 40 nm FPGA).
+
+  We obtain maximum delay numbers by measuring delays of routing, soft logic blocks, 
+  memories, and multipliers from test circuits on a Stratix IV GX device 
+  (EP4SGX230DF29C2X, i.e. fastest speed grade). Minimum delay values are calculated based on the
+  ratios between maximum and minimum values in Stratix IV GX device. For routing, we took the 
+  average delay of H4 and V4 wires.  Rmetal and Cmetal values for the routing wires were obtained 
+  from work done by Charles Chiasson. We use a 96 nm half-pitch (corresponding to mid-level metal 
+  stack 40 nm routing) and take the R and C data from the ITRS roadmap. 
+
+  For the general purpose logic block, we assume that the area and delays of the Stratix IV 
+  crossbar is close enough to the crossbar modelled here.  We use 40 inputs and 20 feedback lines in 
+  the cluster and a full crossbar, leading to 53:1 multiplexers in front of each BLE input.
+  Stratix IV uses 52 inputs and 20 feedback lines, but only a half-populated crossbar, leading to 
+  36:1 multiplexers.  We require 60 such multiplexers, while Stratix IV requires 88 for its more
+  complex fracturable BLEs + the extra control signals. We justify this rough approximation as follows: 
+  The Stratix IV crossbar has more inputs (72 vs. 60) and 
+  outputs (88 vs. 60) than our full crossbar which should increase its area and delay, but the 
+  Stratix IV crossbar is also 50% sparse (each mux is 36:1 instead of 53:1) which should reduce its 
+  area and delay.  The total number of crossbar switch points is roughly similar between the two 
+  architectures (3160 for SIV and 3600 for the academic architecture below), so we use the area 
+  & delay of the Stratix IV crossbar as a rough approximation of our crossbar.
+
+  For LUTs, we include LUT 
+  delays measured from Stratix IV which is dependant on the input used (ie. some 
+  LUT inputs are faster than others).  The CAD tools at the time of VTR 7 does 
+  not consider differences in LUT input delays.
+
+  Adder delays obtained as approximate values from a Stratix IV EP4SE230F29C3 device.  
+  Delay obtained by compiling a 256 bit adder (registered inputs and outputs, 
+  all pins except clock virtual) then measuring the delays in chip-planner, 
+  sumout delay = 0.271ns to 0.348 ns, intra-block carry delay = 0.011 ns, 
+  inter-block carry delay = 0.327 ns.  Given this data, I will approximate 
+  sumout 0.3 ns, intra-block carry-delay = 0.01 ns, and 
+  inter-block carry-delay = 0.16 ns (since Altera inter-block carry delay has 
+  overhead that we don't have, I'll approximate the delay of a simpler chain at 
+  one half what they have.  This is very rough, anything from 0.01ns to 0.327ns 
+  can be justified).
+
+  Logic block area numbers obtained by scaling overall tile area of a 65nm 
+  Stratix III device, (as given in Wong, Betz and Rose, FPGA 2011) to 40 nm, then subtracting out 
+  routing area at a channel width of 300. We use a channel width of 300 because it can route 
+  all the VTR 6.0 benchmark circuits with an approximately 20% safety margin, and is also close to the
+  total channel width of Stratix IV. Hence this channel width is close to the commercial practice of
+  choosing a width that provides high routability. The architecture can be routed at different channel
+  widths, but we estimate the tile size and hence the physical length of routing wires assuming
+  a channel width of 300.
+
+  Sanity checks employed:
+    1.  We confirmed the routing buffer delay is ~1/3rd of total routing delay at L = 4. This matches 
+        common electrical design.
+
+
+  Authors: Jason Luu, Jeff Goeders, Vaughn Betz
+-->
+<architecture>
+  <!-- 
+       ODIN II specific config begins 
+       Describes the types of user-specified netlist blocks (in blif, this corresponds to 
+       ".model [type_of_block]") that this architecture supports.
+
+       Note: Basic LUTs, I/Os, and flip-flops are not included here as there are 
+       already special structures in blif (.names, .input, .output, and .latch) 
+       that describe them.
+  -->
+  <models>
+    <model name="multiply">
+      <input_ports>
+        <port name="a" combinational_sink_ports="out"/>
+        <port name="b" combinational_sink_ports="out"/>
+      </input_ports>
+      <output_ports>
+        <port name="out"/>
+      </output_ports>
+    </model>
+    <model name="single_port_ram">
+      <input_ports>
+        <port name="we" clock="clk"/>
+        <!-- control -->
+        <port name="addr" clock="clk"/>
+        <!-- address lines -->
+        <port name="data" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="dual_port_ram">
+      <input_ports>
+        <port name="we1" clock="clk"/>
+        <!-- write enable -->
+        <port name="we2" clock="clk"/>
+        <!-- write enable -->
+        <port name="addr1" clock="clk"/>
+        <!-- address lines -->
+        <port name="addr2" clock="clk"/>
+        <!-- address lines -->
+        <port name="data1" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="data2" clock="clk"/>
+        <!-- data lines can be broken down into smaller bit widths minimum size 1 -->
+        <port name="clk" is_clock="1"/>
+        <!-- memories are often clocked -->
+      </input_ports>
+      <output_ports>
+        <port name="out1" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+        <port name="out2" clock="clk"/>
+        <!-- output can be broken down into smaller bit widths minimum size 1 -->
+      </output_ports>
+    </model>
+    <model name="adder">
+      <input_ports>
+        <port name="a" combinational_sink_ports="sumout cout"/>
+        <port name="b" combinational_sink_ports="sumout cout"/>
+        <port name="cin" combinational_sink_ports="sumout cout"/>
+      </input_ports>
+      <output_ports>
+        <port name="cout"/>
+        <port name="sumout"/>
+      </output_ports>
+    </model>
+    <!-- Defining a NoC router here, where the inputs come from a AXI interface-->
+    <model name="router">
+      <input_ports>
+        <!-- transaction id-->
+        <port name="id" clock="clk"/>
+        <!-- transaction data-->
+        <port name="payload" clock="clk"/>
+        <!-- transaction control signals-->
+        <port name="ctrl" clock="clk"/>
+        <port name="valid" clock="clk"/>
+        <port name="type"  clock="clk"/>
+        <port name="clk" is_clock="1"/>
+      </input_ports>
+      <output_ports>
+        <!-- packetized data-->
+        <port name="sc_flit" clock="clk"/>
+      </output_ports>
+    </model>  
+  </models>
+  <tiles>
+    <tile name="io" area="0">
+      <sub_tile name="io" capacity="8">
+        <equivalent_sites>
+          <site pb_type="io" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="outpad" num_pins="1"/>
+        <output name="inpad" num_pins="1"/>
+        <clock name="clock" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="custom">
+          <loc side="left">io.outpad io.inpad io.clock</loc>
+          <loc side="top">io.outpad io.inpad io.clock</loc>
+          <loc side="right">io.outpad io.inpad io.clock</loc>
+          <loc side="bottom">io.outpad io.inpad io.clock</loc>
+        </pinlocations>
+      </sub_tile>
+    </tile>
+    <tile name="clb" area="53894">
+      <sub_tile name="clb">
+        <equivalent_sites>
+          <site pb_type="clb" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="I" num_pins="40" equivalent="full"/>
+        <input name="cin" num_pins="1"/>
+        <output name="O" num_pins="20" equivalent="none"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10">
+          <fc_override port_name="cin" fc_type="frac" fc_val="0"/>
+          <fc_override port_name="cout" fc_type="frac" fc_val="0"/>
+        </fc>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <tile name="mult_36" height="4" area="396000">
+      <sub_tile name="mult_36">
+        <equivalent_sites>
+          <site pb_type="mult_36" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="a" num_pins="36"/>
+        <input name="b" num_pins="36"/>
+        <output name="out" num_pins="72"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <tile name="memory" height="6" area="548000">
+      <sub_tile name="memory">
+        <equivalent_sites>
+          <site pb_type="memory" pin_mapping="direct"/>
+        </equivalent_sites>
+        <input name="addr1" num_pins="15"/>
+        <input name="addr2" num_pins="15"/>
+        <input name="data" num_pins="64"/>
+        <input name="we1" num_pins="1"/>
+        <input name="we2" num_pins="1"/>
+        <output name="out" num_pins="64"/>
+        <clock name="clk" num_pins="1"/>
+        <fc in_type="frac" in_val="0.15" out_type="frac" out_val="0.10"/>
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+    <!-- below we specify a NoC router tile. Not sure about the area (might need to update this)-->
+    <tile name="noc_router" width="2" height="2" area="0">
+      <sub_tile name="noc_router">
+        <!-- We need to have a sub tile definition for each physical tile-->
+        <equivalent_sites>
+          <site pb_type="noc_router" pin_mapping="direct"/>
+        </equivalent_sites>
+        <!-- Temporary pin sizes, we need to update this for the future. Pins are not equivalent.-->
+        <input name="id" num_pins="4"/>
+        <input name="payload" num_pins="16"/>
+        <input name="ctrl" num_pins="2"/>
+        <input name="valid" num_pins="1"/>
+        <input name="type" num_pins="8"/>
+        <clock name="clk" num_pins="1"/>
+        <output name="sc_flit" num_pins="32"/>
+        <fc in_type="frac" in_val="0.20" out_type="frac" out_val="0.10"/>
+        <!-- Let us spread the pins throughout the block-->
+        <pinlocations pattern="spread"/>
+      </sub_tile>
+    </tile>
+  </tiles>
+  <!-- ODIN II specific config ends -->
+  <!-- Physical descriptions begin -->
+  <layout>
+    <!-- THis auto layout is used to scale the layout of the tiles for different grid sizes-->
+    <auto_layout aspect_ratio="1.0">
+      <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+      <!-- Instantiate a single NoC router within the device (top left corner) -->
+      <single type="noc_router" x="4" y="H-4" priority="110"/>
+    </auto_layout>
+    <!-- Testing a sample auto layout-->
+    <fixed_layout name="embedded_noc" width="36" height="24">
+	  <!--Perimeter of 'io' blocks with 'EMPTY' blocks at corners-->
+      <perimeter type="io" priority="100"/>
+      <corners type="EMPTY" priority="101"/>
+      <!--Fill with 'clb'-->
+      <fill type="clb" priority="10"/>
+      <!--Column of 'mult_36' with 'EMPTY' blocks wherever a 'mult_36' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="mult_36" startx="6" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="6" repeatx="8" starty="1" priority="19"/>
+      <!--Column of 'memory' with 'EMPTY' blocks wherever a 'memory' does not fit. Vertical offset by 1 for perimeter.-->
+      <col type="memory" startx="2" starty="1" repeatx="8" priority="20"/>
+      <col type="EMPTY" startx="2" repeatx="8" starty="1" priority="19"/>
+      <!-- Instantiate 9 NoC router within the device (4 corners, center, and center of all sides)-->
+      <single type="noc_router" x="1" y="1" priority="110"/>
+      <single type="noc_router" x="1" y="21" priority="110"/>
+      <single type="noc_router" x="33" y="1" priority="110"/>
+      <single type="noc_router" x="33" y="21" priority="110"/>
+      <single type="noc_router" x="16" y="1" priority="110"/>
+      <single type="noc_router" x="16" y="21" priority="110"/>
+      <single type="noc_router" x="1" y="10" priority="110"/>
+      <single type="noc_router" x="33" y="10" priority="110"/>
+      <single type="noc_router" x="16" y="10" priority="110"/>	
+	</fixed_layout>
+  </layout>
+  <device>
+    <!-- VB & JL: Using Ian Kuon's transistor sizing and drive strength data for routing, at 40 nm. Ian used BPTM 
+			     models. We are modifying the delay values however, to include metal C and R, which allows more architecture
+			     experimentation. We are also modifying the relative resistance of PMOS to be 1.8x that of NMOS
+			     (vs. Ian's 3x) as 1.8x lines up with Jeff G's data from a 45 nm process (and is more typical of 
+			     45 nm in general). I'm upping the Rmin_nmos from Ian's just over 6k to nearly 9k, and dropping 
+			     RminW_pmos from 18k to 16k to hit this 1.8x ratio, while keeping the delays of buffers approximately
+			     lined up with Stratix IV. 
+			     We are using Jeff G.'s capacitance data for 45 nm (in tech/ptm_45nm).
+			     Jeff's tables list C in for transistors with widths in multiples of the minimum feature size (45 nm).
+			     The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply drive strength sizes in this file
+	                     by 2.5x when looking up in Jeff's tables.
+			     The delay values are lined up with Stratix IV, which has an architecture similar to this
+			     proposed FPGA, and which is also 40 nm 
+			     C_ipin_cblock: input capacitance of a track buffer, which VPR assumes is a single-stage
+			     4x minimum drive strength buffer. -->
+    <sizing R_minW_nmos="8926" R_minW_pmos="16067"/>
+    <!-- The grid_logic_tile_area below will be used for all blocks that do not explicitly set their own (non-routing)
+     	  area; set to 0 since we explicitly set the area of all blocks currently in this architecture file.
+	    -->
+    <area grid_logic_tile_area="0"/>
+    <chan_width_distr>
+      <x distr="uniform" peak="1.000000"/>
+      <y distr="uniform" peak="1.000000"/>
+    </chan_width_distr>
+    <switch_block type="wilton" fs="3"/>
+    <connection_block input_switch_name="ipin_cblock"/>
+  </device>
+  <switchlist>
+    <!-- VB: the mux_trans_size and buf_size data below is in minimum width transistor *areas*, assuming the purple
+           book area formula. This means the mux transistors are about 5x minimum drive strength.
+           We assume the first stage of the buffer is 3x min drive strength to be reasonable given the large 
+           mux transistors, and this gives a reasonable stage ratio of a bit over 5x to the second stage. We assume
+           the n and p transistors in the first stage are equal-sized to lower the buffer trip point, since it's fed
+           by a pass transistor mux. We can then reverse engineer the buffer second stage to hit the specified 
+           buf_size (really buffer area) - 16.2x minimum drive nmos and 1.8*16.2 = 29.2x minimum drive.
+           I then took the data from Jeff G.'s PTM modeling of 45 nm to get the Cin (gate of first stage) and Cout 
+           (diff of second stage) listed below.  Jeff's models are in tech/ptm_45nm, and are in min feature multiples.
+           The minimum contactable transistor is 2.5 * 45 nm, so I need to multiply the drive strength sizes above by 
+           2.5x when looking up in Jeff's tables.
+           Finally, we choose a switch delay (58 ps) that leads to length 4 wires having a delay equal to that of SIV of 126 ps.
+           This also leads to the switch being 46% of the total wire delay, which is reasonable. -->
+    <switch type="mux" name="0" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+    <!--switch ipin_cblock resistance set to yeild for 4x minimum drive strength buffer-->
+    <switch type="mux" name="ipin_cblock" R="2231.5" Cout="0." Cin="1.47e-15" Tdel="7.247000e-11" mux_trans_size="1.222260" buf_size="auto"/>
+  </switchlist>
+  <segmentlist>
+    <!--- VB & JL: using ITRS metal stack data, 96 nm half pitch wires, which are intermediate metal width/space.  
+             With the 96 nm half pitch, such wires would take 60 um of height, vs. a 90 nm high (approximated as square) Stratix IV tile so this seems
+             reasonable. Using a tile length of 90 nm, corresponding to the length of a Stratix IV tile if it were square. -->
+    <segment freq="1.000000" length="4" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+      <mux name="0"/>
+      <sb type="pattern">1 1 1 1 1</sb>
+      <cb type="pattern">1 1 1 1</cb>
+    </segment>
+  </segmentlist>
+  <directlist>
+    <direct name="adder_carry" from_pin="clb.cout" to_pin="clb.cin" x_offset="0" y_offset="-1" z_offset="0"/>
+  </directlist>
+  <complexblocklist>
+    <!-- Define I/O pads begin -->
+    <!-- Capacity is a unique property of I/Os, it is the maximum number of I/Os that can be placed at the same (X,Y) location on the FPGA -->
+    <!-- Not sure of the area of an I/O (varies widely), and it's not relevant to the design of the FPGA core, so we're setting it to 0. -->
+    <pb_type name="io">
+      <input name="outpad" num_pins="1"/>
+      <output name="inpad" num_pins="1"/>
+      <clock name="clock" num_pins="1"/>
+      <!-- IOs can operate as either inputs or outputs.
+	     Maximum delays below come from Ian Kuon. They are small, so they should be interpreted as
+	     the delays to and from registers in the I/O (and generally I/Os are registered 
+	     today and that is when you timing analyze them.
+
+		 Minimum delays are retrieved using a ratio of maximum and minimum times as seen in Quartus II
+		 in Stratix IV. The ratio of minimum value/maximum value is as follows:
+			inpad delay:  0.9239
+			outpad delay: 0.9545
+
+	     -->
+      <mode name="inpad">
+        <pb_type name="inpad" blif_model=".input" num_pb="1">
+          <output name="inpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="inpad" input="inpad.inpad" output="io.inpad">
+            <delay_constant max="4.243e-11" min="3.92e-11" in_port="inpad.inpad" out_port="io.inpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="outpad">
+        <pb_type name="outpad" blif_model=".output" num_pb="1">
+          <input name="outpad" num_pins="1"/>
+        </pb_type>
+        <interconnect>
+          <direct name="outpad" input="io.outpad" output="outpad.outpad">
+            <delay_constant max="1.394e-11" min="1.331e-11" in_port="io.outpad" out_port="outpad.outpad"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- IOs go on the periphery of the FPGA, for consistency, 
+          make it physically equivalent on all sides so that only one definition of I/Os is needed.
+          If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA
+        -->
+      <!-- Place I/Os on the sides of the FPGA -->
+      <power method="ignore"/>
+    </pb_type>
+    <!-- Define I/O pads ends -->
+    <!-- Define general purpose logic block (CLB) begin -->
+    <!--- Area calculation: Total Stratix IV tile area is about 8100 um^2, and a minimum width transistor 
+	   area is 60 L^2 yields a tile area of 84375 MWTAs.
+	   Routing at W=300 is 30481 MWTAs, leaving us with a total of 53000 MWTAs for logic block area 
+	   This means that only 37% of our area is in the general routing, and 63% is inside the logic
+	   block. Note that the crossbar / local interconnect is considered part of the logic block
+	   area in this analysis. That is a lower proportion of of routing area than most academics
+	   assume, but note that the total routing area really includes the crossbar, which would push
+	   routing area up significantly, we estimate into the ~70% range. 
+	   -->
+    <pb_type name="clb">
+      <input name="I" num_pins="40" equivalent="full"/>
+      <input name="cin" num_pins="1"/>
+      <output name="O" num_pins="20" equivalent="none"/>
+      <output name="cout" num_pins="1"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Describe fracturable logic element.  
+             Each fracturable logic element has a 6-LUT that can alternatively operate as two 5-LUTs with shared inputs. 
+             The outputs of the fracturable logic element can be optionally registered
+        -->
+      <pb_type name="fle" num_pb="10">
+        <input name="in" num_pins="6"/>
+        <input name="cin" num_pins="1"/>
+        <output name="out" num_pins="2"/>
+        <output name="cout" num_pins="1"/>
+        <clock name="clk" num_pins="1"/>
+        <mode name="n2_lut5">
+          <pb_type name="lut5inter" num_pb="1">
+            <input name="in" num_pins="5"/>
+            <input name="cin" num_pins="1"/>
+            <output name="out" num_pins="2"/>
+            <output name="cout" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="ble5" num_pb="2">
+              <input name="in" num_pins="5"/>
+              <input name="cin" num_pins="1"/>
+              <output name="out" num_pins="1"/>
+              <output name="cout" num_pins="1"/>
+              <clock name="clk" num_pins="1"/>
+              <mode name="blut5">
+                <pb_type name="flut5" num_pb="1">
+                  <input name="in" num_pins="5"/>
+                  <output name="out" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Regular LUT mode -->
+                  <pb_type name="lut5" blif_model=".names" num_pb="1" class="lut">
+                    <input name="in" num_pins="5" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <!-- These are the physical maximum delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                           we instead take the average of these numbers to get more stable results
+                        82e-12
+                        173e-12
+                        261e-12
+                        263e-12
+                        398e-12
+							The minimum delay/maximum delay ratio is 0.7395 in QII on Stratix IV. Hence, the minimum delay
+						is 0.7295 * the average of the maximum numbers
+                        -->
+                    <delay_matrix type="max" in_port="lut5.in" out_port="lut5.out">
+                        235e-12
+                        235e-12
+                        235e-12
+                        235e-12
+                        235e-12
+                      </delay_matrix>
+                    <delay_matrix type="min" in_port="lut5.in" out_port="lut5.out">
+                        174e-12
+                        174e-12
+                        174e-12
+                        174e-12
+                        174e-12
+                      </delay_matrix>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_hold value="37e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" min="60e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="direct1" input="flut5.in" output="lut5.in"/>
+                    <direct name="direct2" input="lut5.out" output="ff.D">
+                      <pack_pattern name="ble5" in_port="lut5.out" out_port="ff.D"/>
+                    </direct>
+                    <direct name="direct3" input="flut5.clk" output="ff.clk"/>
+                    <mux name="mux1" input="ff.Q lut5.out" output="flut5.out">
+                      <delay_constant max="25e-12" min="24e-12" in_port="lut5.out" out_port="flut5.out"/>
+                      <delay_constant max="45e-12" min="27e-12" in_port="ff.Q" out_port="flut5.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in" output="flut5.in"/>
+                  <direct name="direct2" input="ble5.clk" output="flut5.clk"/>
+                  <direct name="direct3" input="flut5.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+              <mode name="arithmetic">
+                <pb_type name="arithmetic" num_pb="1">
+                  <input name="in" num_pins="4"/>
+                  <input name="cin" num_pins="1"/>
+                  <output name="out" num_pins="1"/>
+                  <output name="cout" num_pins="1"/>
+                  <clock name="clk" num_pins="1"/>
+                  <!-- Special dual-LUT mode that drives adder only -->
+                  <pb_type name="lut4" blif_model=".names" num_pb="2" class="lut">
+                    <input name="in" num_pins="4" port_class="lut_in"/>
+                    <output name="out" num_pins="1" port_class="lut_out"/>
+                    <!-- LUT timing using delay matrix -->
+                    <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                             we instead take the average of these numbers to get more stable results
+                        82e-12
+                        173e-12
+                        261e-12
+                        263e-12
+							The minimum delay/maximum delay ratio is 0.7395 in QII on Stratix IV. Hence, the minimum delay
+						is 0.7295 * the average of the maximum numbers
+                        -->
+                    <delay_matrix type="max" in_port="lut4.in" out_port="lut4.out">
+                        195e-12
+                        195e-12
+                        195e-12
+                        195e-12
+                      </delay_matrix>
+                    <delay_matrix type="min" in_port="lut4.in" out_port="lut4.out">
+                        144e-12
+                        144e-12
+                        144e-12
+                        144e-12
+                      </delay_matrix>
+                  </pb_type>
+                  <!-- The ratio between minimum and maximum delays in StratixIV for data ports to sumout
+							is 0.6809 and cin to sumout is 0.6969-->
+                  <pb_type name="adder" blif_model=".subckt adder" num_pb="1">
+                    <input name="a" num_pins="1"/>
+                    <input name="b" num_pins="1"/>
+                    <input name="cin" num_pins="1"/>
+                    <output name="cout" num_pins="1"/>
+                    <output name="sumout" num_pins="1"/>
+                    <delay_constant max="0.3e-9" min="0.2043e-9" in_port="adder.a" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" min="0.2043e-9" in_port="adder.b" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" min="0.2043e-9" in_port="adder.cin" out_port="adder.sumout"/>
+                    <delay_constant max="0.3e-9" min="0.2043e-9" in_port="adder.a" out_port="adder.cout"/>
+                    <delay_constant max="0.3e-9" min="0.2043e-9" in_port="adder.b" out_port="adder.cout"/>
+                    <delay_constant max="0.01e-9" min="6.9797e-12" in_port="adder.cin" out_port="adder.cout"/>
+                  </pb_type>
+                  <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+                    <input name="D" num_pins="1" port_class="D"/>
+                    <output name="Q" num_pins="1" port_class="Q"/>
+                    <clock name="clk" num_pins="1" port_class="clock"/>
+                    <T_setup value="66e-12" port="ff.D" clock="clk"/>
+                    <T_hold value="37e-12" port="ff.D" clock="clk"/>
+                    <T_clock_to_Q max="124e-12" min="60e-12" port="ff.Q" clock="clk"/>
+                  </pb_type>
+                  <interconnect>
+                    <direct name="clock" input="arithmetic.clk" output="ff.clk"/>
+                    <direct name="lut_in1" input="arithmetic.in[3:0]" output="lut4[0:0].in[3:0]"/>
+                    <direct name="lut_in2" input="arithmetic.in[3:0]" output="lut4[1:1].in[3:0]"/>
+                    <direct name="lut_to_add1" input="lut4[0:0].out" output="adder.a">
+                      </direct>
+                    <direct name="lut_to_add2" input="lut4[1:1].out" output="adder.b">
+                      </direct>
+                    <direct name="add_to_ff" input="adder.sumout" output="ff.D">
+                      <pack_pattern name="chain" in_port="adder.sumout" out_port="ff.D"/>
+                    </direct>
+                    <direct name="carry_in" input="arithmetic.cin" output="adder.cin">
+                      <pack_pattern name="chain" in_port="arithmetic.cin" out_port="adder.cin"/>
+                    </direct>
+                    <direct name="carry_out" input="adder.cout" output="arithmetic.cout">
+                      <pack_pattern name="chain" in_port="adder.cout" out_port="arithmetic.cout"/>
+                    </direct>
+                    <mux name="sumout" input="ff.Q adder.sumout" output="arithmetic.out">
+                      <delay_constant max="25e-12" min="24e-12" in_port="adder.sumout" out_port="arithmetic.out"/>
+                      <delay_constant max="45e-12" min="27e-12" in_port="ff.Q" out_port="arithmetic.out"/>
+                    </mux>
+                  </interconnect>
+                </pb_type>
+                <interconnect>
+                  <direct name="direct1" input="ble5.in[3:0]" output="arithmetic.in"/>
+                  <direct name="carry_in" input="ble5.cin" output="arithmetic.cin">
+                    <pack_pattern name="chain" in_port="ble5.cin" out_port="arithmetic.cin"/>
+                  </direct>
+                  <direct name="carry_out" input="arithmetic.cout" output="ble5.cout">
+                    <pack_pattern name="chain" in_port="arithmetic.cout" out_port="ble5.cout"/>
+                  </direct>
+                  <direct name="direct2" input="ble5.clk" output="arithmetic.clk"/>
+                  <direct name="direct3" input="arithmetic.out" output="ble5.out"/>
+                </interconnect>
+              </mode>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="lut5inter.in" output="ble5[0:0].in"/>
+              <direct name="direct2" input="lut5inter.in" output="ble5[1:1].in"/>
+              <direct name="direct3" input="ble5[1:0].out" output="lut5inter.out"/>
+              <direct name="carry_in" input="lut5inter.cin" output="ble5[0:0].cin">
+                <pack_pattern name="chain" in_port="lut5inter.cin" out_port="ble5[0:0].cin"/>
+              </direct>
+              <direct name="carry_out" input="ble5[1:1].cout" output="lut5inter.cout">
+                <pack_pattern name="chain" in_port="ble5[1:1].cout" out_port="lut5inter.cout"/>
+              </direct>
+              <direct name="carry_link" input="ble5[0:0].cout" output="ble5[1:1].cin">
+                <pack_pattern name="chain" in_port="ble5[0:0].cout" out_port="ble5[1:1].cout"/>
+              </direct>
+              <complete name="complete1" input="lut5inter.clk" output="ble5[1:0].clk"/>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in[4:0]" output="lut5inter.in"/>
+            <direct name="direct2" input="lut5inter.out" output="fle.out"/>
+            <direct name="direct3" input="fle.clk" output="lut5inter.clk"/>
+            <direct name="carry_in" input="fle.cin" output="lut5inter.cin">
+              <pack_pattern name="chain" in_port="fle.cin" out_port="lut5inter.cin"/>
+            </direct>
+            <direct name="carry_out" input="lut5inter.cout" output="fle.cout">
+              <pack_pattern name="chain" in_port="lut5inter.cout" out_port="fle.cout"/>
+            </direct>
+          </interconnect>
+        </mode>
+        <!-- n2_lut5 -->
+        <mode name="n1_lut6">
+          <pb_type name="ble6" num_pb="1">
+            <input name="in" num_pins="6"/>
+            <output name="out" num_pins="1"/>
+            <clock name="clk" num_pins="1"/>
+            <pb_type name="lut6" blif_model=".names" num_pb="1" class="lut">
+              <input name="in" num_pins="6" port_class="lut_in"/>
+              <output name="out" num_pins="1" port_class="lut_out"/>
+              <!-- LUT timing using delay matrix -->
+              <!-- These are the physical delay inputs on a Stratix IV LUT but because VPR cannot do LUT rebalancing,
+                       we instead take the average of these numbers to get more stable results
+                  82e-12
+                  173e-12
+                  261e-12
+                  263e-12
+                  398e-12
+                  397e-12
+
+					The minimum delay/maximum delay ratio is 0.7395 in QII on Stratix IV. Hence, the minimum delay
+						is 0.7295 * the average of the maximum numbers
+                  -->
+              <delay_matrix type="max" in_port="lut6.in" out_port="lut6.out">
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                  261e-12
+                </delay_matrix>
+              <delay_matrix type="min" in_port="lut6.in" out_port="lut6.out">
+                  174e-12
+                  174e-12
+                  174e-12
+                  174e-12
+                  174e-12
+                  174e-12
+                </delay_matrix>
+            </pb_type>
+            <pb_type name="ff" blif_model=".latch" num_pb="1" class="flipflop">
+              <input name="D" num_pins="1" port_class="D"/>
+              <output name="Q" num_pins="1" port_class="Q"/>
+              <clock name="clk" num_pins="1" port_class="clock"/>
+              <T_setup value="66e-12" port="ff.D" clock="clk"/>
+              <T_hold value="37e-12" port="ff.D" clock="clk"/>
+              <T_clock_to_Q max="124e-12" min="60e-12" port="ff.Q" clock="clk"/>
+            </pb_type>
+            <interconnect>
+              <direct name="direct1" input="ble6.in" output="lut6[0:0].in"/>
+              <direct name="direct2" input="lut6.out" output="ff.D">
+                <pack_pattern name="ble6" in_port="lut6.out" out_port="ff.D"/>
+              </direct>
+              <direct name="direct3" input="ble6.clk" output="ff.clk"/>
+              <mux name="mux1" input="ff.Q lut6.out" output="ble6.out">
+                <delay_constant max="25e-12" min="24e-12" in_port="lut6.out" out_port="ble6.out"/>
+                <delay_constant max="45e-12" min="27e-12" in_port="ff.Q" out_port="ble6.out"/>
+              </mux>
+            </interconnect>
+          </pb_type>
+          <interconnect>
+            <direct name="direct1" input="fle.in" output="ble6.in"/>
+            <direct name="direct2" input="ble6.out" output="fle.out[0:0]"/>
+            <direct name="direct3" input="fle.clk" output="ble6.clk"/>
+          </interconnect>
+        </mode>
+        <!-- n1_lut6 -->
+      </pb_type>
+      <interconnect>
+        <!-- We use a full crossbar to get logical equivalence at inputs of CLB 
+           The delays below come from Stratix IV. the delay through a connection block
+           input mux + the crossbar in Stratix IV is 167 ps. We already have a 72 ps 
+           delay on the connection block input mux (modeled by Ian Kuon), so the remaining
+           delay within the crossbar is 95 ps. 
+		   For the minimum delays, we have the delay through a connection block input mux +
+		   the crossbar in Stratix IV is 144. Subtracting the 72 ps leaves 72 ps remaining.
+           The max delays of cluster feedbacks in Stratix IV is 100 ps, when driven by a LUT.
+           Since all our outputs LUT outputs go to a BLE output, and have a delay of 
+           25 ps to do so, we subtract 25 ps from the 100 ps delay of a feedback
+           to get the part that should be marked on the crossbar. For the minimum delay,
+  		   the value in Stratix IV is 93 ps, subtracting the 24 ps leaves 69 ps.-->
+        <complete name="crossbar" input="clb.I fle[9:0].out" output="fle[9:0].in">
+          <delay_constant max="95e-12" min="72e-12" in_port="clb.I" out_port="fle[9:0].in"/>
+          <delay_constant max="75e-12" min="69e-12" in_port="fle[9:0].out" out_port="fle[9:0].in"/>
+        </complete>
+        <complete name="clks" input="clb.clk" output="fle[9:0].clk">
+          </complete>
+        <!-- This way of specifying direct connection to clb outputs is important because this architecture uses automatic spreading of opins.  
+                 By grouping to output pins in this fashion, if a logic block is completely filled by 6-LUTs, 
+                 then the outputs those 6-LUTs take get evenly distributed across all four sides of the CLB instead of clumped on two sides (which is what happens with a more
+                 naive specification).
+          -->
+        <direct name="clbouts1" input="fle[9:0].out[0:0]" output="clb.O[9:0]"/>
+        <direct name="clbouts2" input="fle[9:0].out[1:1]" output="clb.O[19:10]"/>
+        <!-- Carry chain links -->
+        <direct name="carry_in" input="clb.cin" output="fle[0:0].cin">
+          <!-- Put all inter-block carry chain delay on this one edge -->
+          <delay_constant max="0.16e-9" min="0.11e-9" in_port="clb.cin" out_port="fle[0:0].cin"/>
+          <pack_pattern name="chain" in_port="clb.cin" out_port="fle[0:0].cin"/>
+        </direct>
+        <direct name="carry_out" input="fle[9:9].cout" output="clb.cout">
+          <pack_pattern name="chain" in_port="fle[9:9].cout" out_port="clb.cout"/>
+        </direct>
+        <direct name="carry_link" input="fle[8:0].cout" output="fle[9:1].cin">
+          <pack_pattern name="chain" in_port="fle[8:0].cout" out_port="fle[9:1].cin"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <!-- Define general purpose logic block (CLB) ends -->
+    <!-- Define fracturable multiplier begin -->
+    <!-- This multiplier can operate as a 36x36 multiplier that can fracture to two 18x18 multipliers each of which can further fracture to two 9x9 multipliers 
+	   For delay modelling, the 36x36 DSP multiplier in Stratix IV has a maximum delay of 1.523 ns + 1.93 ns
+	    = 3.45 ns. The average difference between the maximum and minimum values of a dsp mac out in 36 bit multiply
+		mode is 0.51. Hence, the minimum delay is modeled as 0.776 ns + 0.984 ns = 1.760 ns.
+ 		The 18x18 mode doesn't need to sum four 18x18 multipliers, so it is a bit
+	   faster: 1.523 ns for the multiplier, and 1.09 ns for the multiplier output block.
+	    For the input and output interconnect delays, unlike Stratix IV, we don't
+	   have any routing/logic flexibility (crossbars) at the inputs.  There is some output muxing
+	   in Stratix IV and this architecture to select which multiplier outputs should go out (e.g.
+	   9x9 outputs, 18x18 or 36x36) so those are very close between the two architectures. 
+	   We take the conservative (slightly pessimistic)
+           approach modelling the input as the same as the Stratix IV input delay and the output delay the same as the Stratix IV DSP out delay.
+		   
+	   We estimate block area by using the published Stratix III data (which is architecturally identical to Stratix IV)
+	      (H. Wong, V. Betz and J. Rose, "Comparing FPGA vs. Custom CMOS and the Impact on Processor Microarchitecture", FPGA 2011) of 0.2623 
+		  mm^2 and scaling from 65 to 40 nm to obtain 0.0993 mm^2. That area is for a DSP block with approximately 2x the functionality of 
+		  the block we use (can implement two 36x36 multiplies instead of our 1, eight 18x18 multiplies instead of our 4, etc.). Hence we 
+		  divide the area by 2 to obtain 0.0497 mm^2. One minimum-width transistor units = 60 L^2 (where L = 40 nm), so is 518,000 MWTUS. 
+		  That area includes routing and the connection block input muxes.  Our DSP block is four 
+		  rows high, and hence includes four horizontal routing channel segments and four vertical ones, which is 4x the routing of a logic 
+		  block (single tile). It also includes 3.6x the outputs of a logic block, and 1.8x the inputs. Hence a slight overestimate of the routing
+		  area associated with our DSP block is four times that of a logic tile, where the routing area of a logic tile was calculated above (at W = 300)
+		  as 30481 MWTAs. Hence the (core, non-routing) area our DSP block is approximately 518,000 - 4 * 30,481 = 396,000 MWTUs.
+      -->
+    <pb_type name="mult_36">
+      <input name="a" num_pins="36"/>
+      <input name="b" num_pins="36"/>
+      <output name="out" num_pins="72"/>
+      <mode name="two_divisible_mult_18x18">
+        <pb_type name="divisible_mult_18x18" num_pb="2">
+          <input name="a" num_pins="18"/>
+          <input name="b" num_pins="18"/>
+          <output name="out" num_pins="36"/>
+          <!-- Model 9x9 delay and 18x18 delay as the same.  9x9 could be faster, but in Stratix IV
+	          isn't, presumably because the multiplier layout is really optimized for 18x18.
+		-->
+          <mode name="two_mult_9x9">
+            <pb_type name="mult_9x9_slice" num_pb="2">
+              <input name="A_cfg" num_pins="9"/>
+              <input name="B_cfg" num_pins="9"/>
+              <output name="OUT_cfg" num_pins="18"/>
+              <pb_type name="mult_9x9" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="9"/>
+                <input name="b" num_pins="9"/>
+                <output name="out" num_pins="18"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.a" out_port="mult_9x9.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_9x9.b" out_port="mult_9x9.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_9x9_slice.A_cfg" output="mult_9x9.a">
+                </direct>
+                <direct name="b2b" input="mult_9x9_slice.B_cfg" output="mult_9x9.b">
+                </direct>
+                <direct name="out2out" input="mult_9x9.out" output="mult_9x9_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.45e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.45e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_9x9_slice[1:0].A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_9x9_slice[1:0].B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_9x9_slice[1:0].OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <mode name="mult_18x18">
+            <pb_type name="mult_18x18_slice" num_pb="1">
+              <input name="A_cfg" num_pins="18"/>
+              <input name="B_cfg" num_pins="18"/>
+              <output name="OUT_cfg" num_pins="36"/>
+              <pb_type name="mult_18x18" blif_model=".subckt multiply" num_pb="1">
+                <input name="a" num_pins="18"/>
+                <input name="b" num_pins="18"/>
+                <output name="out" num_pins="36"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.a" out_port="mult_18x18.out"/>
+                <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_18x18.b" out_port="mult_18x18.out"/>
+              </pb_type>
+              <interconnect>
+                <direct name="a2a" input="mult_18x18_slice.A_cfg" output="mult_18x18.a">
+                </direct>
+                <direct name="b2b" input="mult_18x18_slice.B_cfg" output="mult_18x18.b">
+                </direct>
+                <direct name="out2out" input="mult_18x18.out" output="mult_18x18_slice.OUT_cfg">
+                </direct>
+              </interconnect>
+              <power method="pin-toggle">
+                <port name="A_cfg" energy_per_toggle="1.09e-12"/>
+                <port name="B_cfg" energy_per_toggle="1.09e-12"/>
+                <static_power power_per_instance="0.0"/>
+              </power>
+            </pb_type>
+            <interconnect>
+              <direct name="a2a" input="divisible_mult_18x18.a" output="mult_18x18_slice.A_cfg">
+              </direct>
+              <direct name="b2b" input="divisible_mult_18x18.b" output="mult_18x18_slice.B_cfg">
+              </direct>
+              <direct name="out2out" input="mult_18x18_slice.OUT_cfg" output="divisible_mult_18x18.out">
+              </direct>
+            </interconnect>
+          </mode>
+          <power method="sum-of-children"/>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading 134 ps
+				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
+              -->
+          <direct name="a2a" input="mult_36.a" output="divisible_mult_18x18[1:0].a">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="divisible_mult_18x18[1:0].a"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="divisible_mult_18x18[1:0].b">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="divisible_mult_18x18[1:0].b"/>
+          </direct>
+          <direct name="out2out" input="divisible_mult_18x18[1:0].out" output="mult_36.out">
+            <delay_constant max="1.09e-9" min="74e-12" in_port="divisible_mult_18x18[1:0].out" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mult_36x36">
+        <pb_type name="mult_36x36_slice" num_pb="1">
+          <input name="A_cfg" num_pins="36"/>
+          <input name="B_cfg" num_pins="36"/>
+          <output name="OUT_cfg" num_pins="72"/>
+          <pb_type name="mult_36x36" blif_model=".subckt multiply" num_pb="1">
+            <input name="a" num_pins="36"/>
+            <input name="b" num_pins="36"/>
+            <output name="out" num_pins="72"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.a" out_port="mult_36x36.out"/>
+            <delay_constant max="1.523e-9" min="0.776e-9" in_port="mult_36x36.b" out_port="mult_36x36.out"/>
+          </pb_type>
+          <interconnect>
+            <direct name="a2a" input="mult_36x36_slice.A_cfg" output="mult_36x36.a">
+            </direct>
+            <direct name="b2b" input="mult_36x36_slice.B_cfg" output="mult_36x36.b">
+            </direct>
+            <direct name="out2out" input="mult_36x36.out" output="mult_36x36_slice.OUT_cfg">
+            </direct>
+          </interconnect>
+          <power method="pin-toggle">
+            <port name="A_cfg" energy_per_toggle="2.13e-12"/>
+            <port name="B_cfg" energy_per_toggle="2.13e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <!-- Stratix IV input delay of 207ps is conservative for this architecture because this architecture does not have an input crossbar in the multiplier. 
+		   Subtract 72.5 ps delay, which is already in the connection block input mux, leading
+		   to a 134 ps delay.
+				The interconnect difference for DSP blocks is 0.5523, which leads to a minimum delay of 74 ps
+              -->
+          <direct name="a2a" input="mult_36.a" output="mult_36x36_slice.A_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.a" out_port="mult_36x36_slice.A_cfg"/>
+          </direct>
+          <direct name="b2b" input="mult_36.b" output="mult_36x36_slice.B_cfg">
+            <delay_constant max="134e-12" min="74e-12" in_port="mult_36.b" out_port="mult_36x36_slice.B_cfg"/>
+          </direct>
+          <direct name="out2out" input="mult_36x36_slice.OUT_cfg" output="mult_36.out">
+            <delay_constant max="1.93e-9" min="74e-12" in_port="mult_36x36_slice.OUT_cfg" out_port="mult_36.out"/>
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Place this multiplier block every 8 columns from (and including) the sixth column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable multiplier end -->
+    <!-- Define fracturable memory begin -->
+    <!-- 32 Kb Memory that can operate from 512x64 to 32Kx1 for single-port mode and 1024x32 to 32Kx1 for dual-port mode.  
+           Area and max delay based off Stratix IV 9K and 144K memories (delay from linear interpolation, Tsu(483 ps, 636 ps) Tco(1084ps, 1969ps)).  
+
+		   uTh/Tsu ratio = 0.468, uTco min/max ratio = 0.97
+           uTh = 226ps, 298ps
+           Min uTco = 1051ps, 1909ps
+           Max input delay = 204ps (from Stratix IV LAB line) - 72ps (this architecture does not lump connection box delay in internal delay)
+           Max output delay = M9K buffer 50ps. 
+		   Min input delay = 160ps (from Stratix IV Lab line) - 72ps
+		   Min output delay = 46ps (M9K buffer min/max ratio = 0.9286)
+		   
+		   Area is obtained by appropriately scaling and adjusting the published Stratix III (which is architecturally identical to Stratix IV)
+		   data from H. Wong, V. Betz and J. Rose, "Comparing FPGA vs. Custom CMOS and the Impact on Processor Microarchitecture", FPGA 2011.
+		   Linearly interpolating (by bit count) between the M9k and M144k areas to obtain an M32k (our RAM size) point yields a 65 nm area of
+		   of 0.153 mm^2. Interpolating based on port count between the RAMs would instead yield an area of 0.209 mm^2 for our 32 kB RAM; since 
+		   bit count accounts for more area than ports for a RAM this size we choose the bit count interpolation; however, since the port interpolation
+		   is not radically different this also gives us confidence that interpolating based on bits is OK, but slightly underpredicts area.
+		   Scaling to 40 nm^2 yields .0579 mm^2, and converting to MWTUs at 60 L^2 / MWTU yields 604,000 MWTUs. This includes routing. A Stratix IV
+		   M9K RAM is one row high and hence has one routing tile (one horizonal and one vertical routing segment area). An M144k RAM has 8 such tiles.
+		   Linearly interpolating on
+		   bits to 32 kb yields 2.2 routing tiles incorporated in the area number above. The inter-block routing represents 30% of the area of a logic 
+		   tile according to D. Lewis et al, "Architectural Enhancements in Stratix V," FPGA 2013. Hence we should subtract 0.3 * 2.2 * 84,375 MWTUs to
+		   obtain a RAM core area (not including inter-block routing) of 548,000 MWTU areas for our 32 kb RAM in a 40 nm process.
+      -->
+    <pb_type name="memory">
+      <input name="addr1" num_pins="15"/>
+      <input name="addr2" num_pins="15"/>
+      <input name="data" num_pins="64"/>
+      <input name="we1" num_pins="1"/>
+      <input name="we2" num_pins="1"/>
+      <output name="out" num_pins="64"/>
+      <clock name="clk" num_pins="1"/>
+      <!-- Specify single port mode first -->
+      <mode name="mem_512x64_sp">
+        <pb_type name="mem_512x64_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="9" port_class="address"/>
+          <input name="data" num_pins="64" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="64" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_512x64_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_512x64_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[8:0]" output="mem_512x64_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[8:0]" out_port="mem_512x64_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[63:0]" output="mem_512x64_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:0]" out_port="mem_512x64_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_512x64_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_512x64_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_512x64_sp.out" output="memory.out[63:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_512x64_sp.out" out_port="memory.out[63:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_512x64_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_1024x32_sp">
+        <pb_type name="mem_1024x32_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="10" port_class="address"/>
+          <input name="data" num_pins="32" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="32" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_sp.out" output="memory.out[31:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_sp.out" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x32_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_sp">
+        <pb_type name="mem_2048x16_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="11" port_class="address"/>
+          <input name="data" num_pins="16" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="16" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_sp.out" output="memory.out[15:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_sp.out" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x16_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_4096x8_sp">
+        <pb_type name="mem_4096x8_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="12" port_class="address"/>
+          <input name="data" num_pins="8" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="8" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_4096x8_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_4096x8_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_4096x8_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_4096x8_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_4096x8_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_4096x8_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_4096x8_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_4096x8_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_4096x8_sp.out" output="memory.out[7:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_4096x8_sp.out" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_4096x8_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_sp">
+        <pb_type name="mem_8192x4_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="13" port_class="address"/>
+          <input name="data" num_pins="4" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="4" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_sp.out" output="memory.out[3:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_sp.out" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_8192x4_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_sp">
+        <pb_type name="mem_16384x2_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="14" port_class="address"/>
+          <input name="data" num_pins="2" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="2" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_sp.out" output="memory.out[1:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_sp.out" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_16384x2_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_sp">
+        <pb_type name="mem_32768x1_sp" blif_model=".subckt single_port_ram" class="memory" num_pb="1">
+          <input name="addr" num_pins="15" port_class="address"/>
+          <input name="data" num_pins="1" port_class="data_in"/>
+          <input name="we" num_pins="1" port_class="write_en"/>
+          <output name="out" num_pins="1" port_class="data_out"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.addr" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.data" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_sp.we" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_sp.out" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="9.0e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_sp.addr">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_sp.addr"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_sp.data">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_sp.data"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_sp.we">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_sp.we"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_sp.out" output="memory.out[0:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_sp.out" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_32768x1_sp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Specify true dual port mode next -->
+      <mode name="mem_1024x32_dp">
+        <pb_type name="mem_1024x32_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="10" port_class="address1"/>
+          <input name="addr2" num_pins="10" port_class="address2"/>
+          <input name="data1" num_pins="32" port_class="data_in1"/>
+          <input name="data2" num_pins="32" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="32" port_class="data_out1"/>
+          <output name="out2" num_pins="32" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_1024x32_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_1024x32_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[9:0]" output="mem_1024x32_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[9:0]" out_port="mem_1024x32_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[9:0]" output="mem_1024x32_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[9:0]" out_port="mem_1024x32_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[31:0]" output="mem_1024x32_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:0]" out_port="mem_1024x32_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[63:32]" output="mem_1024x32_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[63:32]" out_port="mem_1024x32_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_1024x32_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_1024x32_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_1024x32_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_1024x32_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_1024x32_dp.out1" output="memory.out[31:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out1" out_port="memory.out[31:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_1024x32_dp.out2" output="memory.out[63:32]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_1024x32_dp.out2" out_port="memory.out[63:32]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_1024x32_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x16_dp">
+        <pb_type name="mem_2048x16_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="11" port_class="address1"/>
+          <input name="addr2" num_pins="11" port_class="address2"/>
+          <input name="data1" num_pins="16" port_class="data_in1"/>
+          <input name="data2" num_pins="16" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="16" port_class="data_out1"/>
+          <output name="out2" num_pins="16" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x16_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x16_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[10:0]" output="mem_2048x16_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[10:0]" out_port="mem_2048x16_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[10:0]" output="mem_2048x16_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[10:0]" out_port="mem_2048x16_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[15:0]" output="mem_2048x16_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:0]" out_port="mem_2048x16_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[31:16]" output="mem_2048x16_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[31:16]" out_port="mem_2048x16_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x16_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x16_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_2048x16_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_2048x16_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x16_dp.out1" output="memory.out[15:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out1" out_port="memory.out[15:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_2048x16_dp.out2" output="memory.out[31:16]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x16_dp.out2" out_port="memory.out[31:16]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x16_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_2048x8_dp">
+        <pb_type name="mem_2048x8_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="12" port_class="address1"/>
+          <input name="addr2" num_pins="12" port_class="address2"/>
+          <input name="data1" num_pins="8" port_class="data_in1"/>
+          <input name="data2" num_pins="8" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="8" port_class="data_out1"/>
+          <output name="out2" num_pins="8" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_2048x8_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x8_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x8_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x8_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x8_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x8_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_2048x8_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x8_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_2048x8_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[11:0]" output="mem_2048x8_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[11:0]" out_port="mem_2048x8_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[11:0]" output="mem_2048x8_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[11:0]" out_port="mem_2048x8_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[7:0]" output="mem_2048x8_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:0]" out_port="mem_2048x8_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[15:8]" output="mem_2048x8_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[15:8]" out_port="mem_2048x8_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_2048x8_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_2048x8_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_2048x8_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_2048x8_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_2048x8_dp.out1" output="memory.out[7:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x8_dp.out1" out_port="memory.out[7:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_2048x8_dp.out2" output="memory.out[15:8]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_2048x8_dp.out2" out_port="memory.out[15:8]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_2048x8_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_8192x4_dp">
+        <pb_type name="mem_8192x4_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="13" port_class="address1"/>
+          <input name="addr2" num_pins="13" port_class="address2"/>
+          <input name="data1" num_pins="4" port_class="data_in1"/>
+          <input name="data2" num_pins="4" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="4" port_class="data_out1"/>
+          <output name="out2" num_pins="4" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_8192x4_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_8192x4_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[12:0]" output="mem_8192x4_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[12:0]" out_port="mem_8192x4_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[12:0]" output="mem_8192x4_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[12:0]" out_port="mem_8192x4_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[3:0]" output="mem_8192x4_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:0]" out_port="mem_8192x4_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[7:4]" output="mem_8192x4_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[7:4]" out_port="mem_8192x4_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_8192x4_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_8192x4_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_8192x4_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_8192x4_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_8192x4_dp.out1" output="memory.out[3:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out1" out_port="memory.out[3:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_8192x4_dp.out2" output="memory.out[7:4]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_8192x4_dp.out2" out_port="memory.out[7:4]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_8192x4_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_16384x2_dp">
+        <pb_type name="mem_16384x2_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="14" port_class="address1"/>
+          <input name="addr2" num_pins="14" port_class="address2"/>
+          <input name="data1" num_pins="2" port_class="data_in1"/>
+          <input name="data2" num_pins="2" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="2" port_class="data_out1"/>
+          <output name="out2" num_pins="2" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_16384x2_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_16384x2_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[13:0]" output="mem_16384x2_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[13:0]" out_port="mem_16384x2_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[13:0]" output="mem_16384x2_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[13:0]" out_port="mem_16384x2_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[1:0]" output="mem_16384x2_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:0]" out_port="mem_16384x2_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[3:2]" output="mem_16384x2_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[3:2]" out_port="mem_16384x2_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_16384x2_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_16384x2_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_16384x2_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_16384x2_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_16384x2_dp.out1" output="memory.out[1:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out1" out_port="memory.out[1:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_16384x2_dp.out2" output="memory.out[3:2]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_16384x2_dp.out2" out_port="memory.out[3:2]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_16384x2_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <mode name="mem_32768x1_dp">
+        <pb_type name="mem_32768x1_dp" blif_model=".subckt dual_port_ram" class="memory" num_pb="1">
+          <input name="addr1" num_pins="15" port_class="address1"/>
+          <input name="addr2" num_pins="15" port_class="address2"/>
+          <input name="data1" num_pins="1" port_class="data_in1"/>
+          <input name="data2" num_pins="1" port_class="data_in2"/>
+          <input name="we1" num_pins="1" port_class="write_en1"/>
+          <input name="we2" num_pins="1" port_class="write_en2"/>
+          <output name="out1" num_pins="1" port_class="data_out1"/>
+          <output name="out2" num_pins="1" port_class="data_out2"/>
+          <clock name="clk" num_pins="1" port_class="clock"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_setup value="509e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.addr1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.data1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.we1" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.addr2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.data2" clock="clk"/>
+          <T_hold value="238e-12" port="mem_32768x1_dp.we2" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out1" clock="clk"/>
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="mem_32768x1_dp.out2" clock="clk"/>
+          <power method="pin-toggle">
+            <port name="clk" energy_per_toggle="17.9e-12"/>
+            <static_power power_per_instance="0.0"/>
+          </power>
+        </pb_type>
+        <interconnect>
+          <direct name="address1" input="memory.addr1[14:0]" output="mem_32768x1_dp.addr1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr1[14:0]" out_port="mem_32768x1_dp.addr1"/>
+          </direct>
+          <direct name="address2" input="memory.addr2[14:0]" output="mem_32768x1_dp.addr2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.addr2[14:0]" out_port="mem_32768x1_dp.addr2"/>
+          </direct>
+          <direct name="data1" input="memory.data[0:0]" output="mem_32768x1_dp.data1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[0:0]" out_port="mem_32768x1_dp.data1"/>
+          </direct>
+          <direct name="data2" input="memory.data[1:1]" output="mem_32768x1_dp.data2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.data[1:1]" out_port="mem_32768x1_dp.data2"/>
+          </direct>
+          <direct name="writeen1" input="memory.we1" output="mem_32768x1_dp.we1">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we1" out_port="mem_32768x1_dp.we1"/>
+          </direct>
+          <direct name="writeen2" input="memory.we2" output="mem_32768x1_dp.we2">
+            <delay_constant max="132e-12" min="88e-12" in_port="memory.we2" out_port="mem_32768x1_dp.we2"/>
+          </direct>
+          <direct name="dataout1" input="mem_32768x1_dp.out1" output="memory.out[0:0]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out1" out_port="memory.out[0:0]"/>
+          </direct>
+          <direct name="dataout2" input="mem_32768x1_dp.out2" output="memory.out[1:1]">
+            <delay_constant max="50e-12" min="46e-12" in_port="mem_32768x1_dp.out2" out_port="memory.out[1:1]"/>
+          </direct>
+          <direct name="clk" input="memory.clk" output="mem_32768x1_dp.clk">
+          </direct>
+        </interconnect>
+      </mode>
+      <!-- Every input pin is driven by 15% of the tracks in a channel, every output pin is driven by 10% of the tracks in a channel -->
+      <!-- Place this memory block every 8 columns from (and including) the second column -->
+      <power method="sum-of-children"/>
+    </pb_type>
+    <!-- Define fracturable memory end -->
+    <!-- Define NoC router below-->
+    <!-- The initial definition of this NoC router is a block that has internal registering of the the input and output signals
+          and then a bit of combination delay is added within the block. Did not include power values either. -->
+    <pb_type name="noc_router">
+      <input name="id" num_pins="4"/>
+      <input name="payload" num_pins="16"/>
+      <input name="ctrl" num_pins="2"/>
+      <input name="valid" num_pins="1"/>
+      <input name="type" num_pins="8"/>
+      <clock name="clk" num_pins="1"/>
+      <output name="sc_flit" num_pins="32"/>
+      <!-- There is only a single mode right now -->
+      <mode name="noc_router_basic">
+        <pb_type name="noc_router_basic" blif_model=".subckt router" num_pb="1">
+          <input name="id" num_pins="4"/>
+          <input name="payload" num_pins="16"/>
+          <input name="ctrl" num_pins="2"/>
+          <input name="valid" num_pins="1"/>
+          <input name="type" num_pins="8"/>
+          <clock name="clk" num_pins="1"/>
+          <output name="sc_flit" num_pins="32"/>
+          <!-- Defining some timing constrains of the router (for now we are going to mimic the memory blocks) -->
+          <T_setup value="509e-12" port="noc_router_basic.id" clock="clk"/>
+          <T_setup value="509e-12" port="noc_router_basic.payload" clock="clk"/>
+          <T_setup value="509e-12" port="noc_router_basic.ctrl" clock="clk"/>
+          <T_setup value="509e-12" port="noc_router_basic.valid" clock="clk"/>
+          <T_setup value="509e-12" port="noc_router_basic.type" clock="clk"/>
+          <T_setup value="509e-12" port="noc_router_basic.sc_flit" clock="clk"/>
+          
+          <T_hold value="238e-12" port="noc_router_basic.id" clock="clk"/>
+          <T_hold value="238e-12" port="noc_router_basic.payload" clock="clk"/>
+          <T_hold value="238e-12" port="noc_router_basic.ctrl" clock="clk"/>
+          <T_hold value="238e-12" port="noc_router_basic.valid" clock="clk"/>
+          <T_hold value="238e-12" port="noc_router_basic.type" clock="clk"/>
+
+
+          <T_clock_to_Q max="1.234e-9" min="1.196e-9" port="noc_router_basic.sc_flit" clock="clk"/>
+          
+          <!-- delays we dont need
+          <delay_constant max="1.523e-9" in_port="noc_router_basic.id" out_port="noc_router_basic.sc_flit"/>
+          <delay_constant max="1.523e-9" in_port="noc_router_basic.payload" out_port="noc_router_basic.sc_flit"/>
+          <delay_constant max="1.523e-9" in_port="noc_router_basic.ctrl" out_port="noc_router_basic.sc_flit"/>
+          <delay_constant max="1.523e-9" in_port="noc_router_basic.valid" out_port="noc_router_basic.sc_flit"/>
+          <delay_constant max="1.523e-9" in_port="noc_router_basic.type" out_port="noc_router_basic.sc_flit"/>  -->
+        </pb_type>
+        <interconnect>
+          <!-- Not adding any wire delay for now-->
+          <direct name="id_connection" input="noc_router.id" output="noc_router_basic.id">
+          </direct>
+          <direct name="payload_connection" input="noc_router.payload" output="noc_router_basic.payload">
+          </direct>
+          <direct name="ctrl_connection" input="noc_router.ctrl" output="noc_router_basic.ctrl">
+          </direct>
+          <direct name="valid_connection" input="noc_router.valid" output="noc_router_basic.valid">
+          </direct>
+          <direct name="type_connection" input="noc_router.type" output="noc_router_basic.type">
+          </direct>
+          <direct name="output_connection" input="noc_router_basic.sc_flit" output="noc_router.sc_flit">
+          </direct>
+          <direct name="clock_connection" input="noc_router.clk" output="noc_router_basic.clk">
+          </direct>
+        </interconnect>
+      </mode>
+    </pb_type>
+    <!-- Define NoC router end -->
+  </complexblocklist>
+  <power>
+    <local_interconnect C_wire="2.5e-10"/>
+    <mux_transistor_size mux_transistor_size="3"/>
+    <FF_size FF_size="4"/>
+    <LUT_transistor_size LUT_transistor_size="4"/>
+  </power>
+  <clocks>
+    <clock buffer_size="auto" C_wire="2.5e-10"/>
+  </clocks>
+  <!-- The NoC routers were added to the FPGA device in the fixed layout section-->
+  <noc link_latency="1e-9" router_latency="2e-9" link_bandwidth="1.2e9" noc_router_tile_name="noc_router">
+    <mesh startx="0" endx="5" starty="0" endy="5" size="2"/>
+  </noc>
+</architecture>

--- a/fpga_arch_viewer/src/grid.rs
+++ b/fpga_arch_viewer/src/grid.rs
@@ -1,4 +1,5 @@
 use fpga_arch_parser::{AutoLayout, FPGAArch, GridLocation};
+use log::warn;
 use std::collections::HashMap;
 
 // A single cell in the FPGA grid
@@ -383,9 +384,16 @@ impl DeviceGrid {
                         .and_then(|expr| self.eval_expr(expr, tile_width, tile_height))
                         .unwrap_or(self.width);
 
-                    for x in (start_x..self.width).step_by(repeat_x) {
-                        for y in (start_y..self.height).step_by(incr_y) {
-                            self.place_tile(y, x, &col_loc.pb_type, col_loc.priority, die_id);
+                    if repeat_x == 0 || incr_y == 0 {
+                        warn!(
+                            "Skipping col tile placement for '{}': step_by value is zero (repeat_x={repeat_x}, incr_y={incr_y})",
+                            col_loc.pb_type
+                        );
+                    } else {
+                        for x in (start_x..self.width).step_by(repeat_x) {
+                            for y in (start_y..self.height).step_by(incr_y) {
+                                self.place_tile(y, x, &col_loc.pb_type, col_loc.priority, die_id);
+                            }
                         }
                     }
                 }
@@ -405,9 +413,16 @@ impl DeviceGrid {
                         .and_then(|expr| self.eval_expr(expr, tile_width, tile_height))
                         .unwrap_or(self.height);
 
-                    for y in (start_y..self.height).step_by(repeat_y) {
-                        for x in (start_x..self.width).step_by(incr_x) {
-                            self.place_tile(y, x, &row_loc.pb_type, row_loc.priority, die_id);
+                    if repeat_y == 0 || incr_x == 0 {
+                        warn!(
+                            "Skipping row tile placement for '{}': step_by value is zero (repeat_y={repeat_y}, incr_x={incr_x})",
+                            row_loc.pb_type
+                        );
+                    } else {
+                        for y in (start_y..self.height).step_by(repeat_y) {
+                            for x in (start_x..self.width).step_by(incr_x) {
+                                self.place_tile(y, x, &row_loc.pb_type, row_loc.priority, die_id);
+                            }
                         }
                     }
                 }
@@ -427,9 +442,16 @@ impl DeviceGrid {
                         .eval_expr(&region.incr_y_expr, tile_width, tile_height)
                         .unwrap_or(end_y - start_y + 1);
 
-                    for y in (start_y..=end_y.min(self.height - 1)).step_by(incr_y) {
-                        for x in (start_x..=end_x.min(self.width - 1)).step_by(incr_x) {
-                            self.place_tile(y, x, &region.pb_type, region.priority, die_id);
+                    if incr_y == 0 || incr_x == 0 {
+                        warn!(
+                            "Skipping region tile placement for '{}': step_by value is zero (incr_y={incr_y}, incr_x={incr_x})",
+                            region.pb_type
+                        );
+                    } else {
+                        for y in (start_y..=end_y.min(self.height - 1)).step_by(incr_y) {
+                            for x in (start_x..=end_x.min(self.width - 1)).step_by(incr_x) {
+                                self.place_tile(y, x, &region.pb_type, region.priority, die_id);
+                            }
                         }
                     }
                 }

--- a/fpga_arch_viewer/src/grid_renderer.rs
+++ b/fpga_arch_viewer/src/grid_renderer.rs
@@ -204,9 +204,13 @@ impl GridRenderer {
                 if state.show_noc
                     && let Some(noc_info) = &arch.noc
                 {
-                    // Create a lookup between each router and their positions.
+                    // Build a position lookup for all routers, but only
+                    // include routers on the currently selected die.
                     let mut router_positions = HashMap::new();
                     for router in &noc_info.topology.routers {
+                        if router.layer != state.selected_die_id {
+                            continue;
+                        }
                         let x_pos = router.position_x * cell_size;
                         let y_pos = (grid.height as f32 - router.position_y) * cell_size;
                         router_positions.insert(router.id, offset + egui::vec2(x_pos, y_pos));
@@ -214,11 +218,15 @@ impl GridRenderer {
 
                     let mut noc_shapes: Vec<egui::Shape> = Vec::new();
 
-                    // Draw each router's connections.
+                    // Draw connections between routers on this die only.
                     for router in &noc_info.topology.routers {
-                        let from_pos = router_positions[&router.id];
+                        let Some(&from_pos) = router_positions.get(&router.id) else {
+                            continue;
+                        };
                         for target_id in &router.connections {
-                            let to_pos = router_positions[target_id];
+                            let Some(&to_pos) = router_positions.get(target_id) else {
+                                continue;
+                            };
                             noc_shapes.push(egui::Shape::line_segment(
                                 [from_pos, to_pos],
                                 egui::Stroke::new(2.0, egui::Color32::BLACK),
@@ -226,7 +234,7 @@ impl GridRenderer {
                         }
                     }
 
-                    // Draw each router.
+                    // Draw each router on this die.
                     for router_position in router_positions.values() {
                         noc_shapes.push(egui::Shape::circle_filled(
                             *router_position,


### PR DESCRIPTION
The mesh tag was not documented so it was not being parsed. Updated the docs in another PR on VTR and used those updated docs to add a parser for it in the visualizer.

Resolves #118 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for mesh Network-on-Chip (NoC) topology parsing with layer-based configuration
  * Multi-layer NoC rendering with per-layer router filtering

* **Bug Fixes**
  * Prevented errors in grid placement with zero-step values
  * Fixed NoC connection rendering to properly display only active layer routers

* **Tests**
  * Added integration tests for mesh NoC topology validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->