### PR TITLE
[ComplexBlock] Added ComplexBlockGraph

### DIFF
--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -42,7 +42,7 @@ pub enum PortClass {
 
 pub struct InputPort {
     pub name: String,
-    pub num_pins: i32,
+    pub num_pins: usize,
     pub equivalent: PinEquivalence,
     pub is_non_clock_global: bool,
     pub port_class: PortClass,
@@ -50,14 +50,14 @@ pub struct InputPort {
 
 pub struct OutputPort {
     pub name: String,
-    pub num_pins: i32,
+    pub num_pins: usize,
     pub equivalent: PinEquivalence,
     pub port_class: PortClass,
 }
 
 pub struct ClockPort {
     pub name: String,
-    pub num_pins: i32,
+    pub num_pins: usize,
     pub equivalent: PinEquivalence,
     pub port_class: PortClass,
 }

--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -1,4 +1,4 @@
-use crate::tile_pin_mapper::TilePinMapper;
+use crate::{complex_block_graph::ComplexBlockGraph, tile_pin_mapper::TilePinMapper};
 
 pub struct ModelPort {
     pub name: String,
@@ -607,6 +607,7 @@ pub struct PBMode {
     pub metadata: Option<Vec<Metadata>>,
 }
 
+#[derive(Clone)]
 pub enum PBTypeClass {
     None,
     Lut,
@@ -658,5 +659,6 @@ pub struct FPGAArch {
     pub custom_switch_blocks: Vec<CustomSwitchBlock>,
     pub direct_list: Vec<GlobalDirect>,
     pub complex_block_list: Vec<PBType>,
+    pub complex_block_graphs: Vec<ComplexBlockGraph>,
     pub noc: Option<NoCInfo>,
 }

--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -593,6 +593,9 @@ pub enum PBTypeClass {
     Lut,
     FlipFlop,
     Memory,
+    InterconnectDirect,
+    InterconnectMux,
+    InterconnectComplete,
 }
 
 pub struct PBType {

--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -600,7 +600,7 @@ pub enum PBTypeClass {
 
 pub struct PBType {
     pub name: String,
-    pub num_pb: i32,
+    pub num_pb: usize,
     pub blif_model: Option<String>,
     pub class: PBTypeClass,
     pub ports: Vec<Port>,

--- a/fpga_arch_parser/src/arch.rs
+++ b/fpga_arch_parser/src/arch.rs
@@ -564,40 +564,20 @@ pub struct PackPattern {
     pub out_port: String,
 }
 
-pub struct CompleteInterconnect {
+pub enum InterconnectType {
+    Complete,
+    Direct,
+    Mux,
+}
+
+pub struct Interconnect {
     pub name: String,
     pub input: String,
     pub output: String,
-    // FIXME: The documentation needs to be updated. The documentation says there
-    //        may be a single pack pattern; however, an interconnect may have many
-    //        pack patterns.
+    pub interconnect_type: InterconnectType,
     pub pack_patterns: Vec<PackPattern>,
     pub delays: Vec<DelayInfo>,
     pub metadata: Option<Vec<Metadata>>,
-}
-
-pub struct DirectInterconnect {
-    pub name: String,
-    pub input: String,
-    pub output: String,
-    pub pack_patterns: Vec<PackPattern>,
-    pub delays: Vec<DelayInfo>,
-    pub metadata: Option<Vec<Metadata>>,
-}
-
-pub struct MuxInterconnect {
-    pub name: String,
-    pub input: String,
-    pub output: String,
-    pub pack_patterns: Vec<PackPattern>,
-    pub delays: Vec<DelayInfo>,
-    pub metadata: Option<Vec<Metadata>>,
-}
-
-pub enum Interconnect {
-    Complete(CompleteInterconnect),
-    Direct(DirectInterconnect),
-    Mux(MuxInterconnect),
 }
 
 pub struct PBMode {

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -204,7 +204,7 @@ fn add_pb_type_recursive(
         let mut child_ids: Vec<ComplexBlockNodeId> = Vec::new();
         let mut children_by_name: HashMap<String, Vec<ComplexBlockNodeId>> = HashMap::new();
         for child in children {
-            for _ in 0..child.num_pb as usize {
+            for _ in 0..child.num_pb {
                 let child_id =
                     add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins)?;
                 child_ids.push(child_id);

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -1,4 +1,3 @@
-
 use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 
@@ -81,7 +80,9 @@ pub struct ComplexBlockGraph {
     pub complex_block_pins: Vec<ComplexBlockPin>,
 }
 
-pub fn build_complex_block_graph(root_pb_type: &PBType) -> Result<ComplexBlockGraph, FPGAArchParseError> {
+pub fn build_complex_block_graph(
+    root_pb_type: &PBType,
+) -> Result<ComplexBlockGraph, FPGAArchParseError> {
     // Traverse the pb-type heirarchy using a child-first-order traversal, building the children complex blocks first
     // and then constructing their parents.
     let mut nodes: Vec<ComplexBlockNode> = Vec::new();
@@ -89,7 +90,14 @@ pub fn build_complex_block_graph(root_pb_type: &PBType) -> Result<ComplexBlockGr
     let mut ports: Vec<ComplexBlockPort> = Vec::new();
     let mut pins: Vec<ComplexBlockPin> = Vec::new();
 
-    let root_id = add_pb_type_recursive(root_pb_type, None, &mut nodes, &mut modes, &mut ports, &mut pins)?;
+    let root_id = add_pb_type_recursive(
+        root_pb_type,
+        None,
+        &mut nodes,
+        &mut modes,
+        &mut ports,
+        &mut pins,
+    )?;
 
     Ok(ComplexBlockGraph {
         root_complex_block_node: root_id,
@@ -123,48 +131,69 @@ fn add_pb_type_recursive(
     // Build ports and pins for this node.
     for port in &pb_type.ports {
         let (port_name, num_pins) = match port {
-            Port::Input(p)  => (p.name.clone(), p.num_pins),
+            Port::Input(p) => (p.name.clone(), p.num_pins),
             Port::Output(p) => (p.name.clone(), p.num_pins),
-            Port::Clock(p)  => (p.name.clone(), p.num_pins),
+            Port::Clock(p) => (p.name.clone(), p.num_pins),
         };
         let port_id = ComplexBlockPortId(ports.len());
-        let pin_ids: Vec<ComplexBlockPinId> = (0..num_pins as usize).map(|_| {
-            let pin_id = ComplexBlockPinId(pins.len());
-            pins.push(ComplexBlockPin { parent_port: port_id });
-            pin_id
-        }).collect();
-        ports.push(ComplexBlockPort { name: port_name, parent_complex_block: node_id, pins: pin_ids });
+        let pin_ids: Vec<ComplexBlockPinId> = (0..num_pins as usize)
+            .map(|_| {
+                let pin_id = ComplexBlockPinId(pins.len());
+                pins.push(ComplexBlockPin {
+                    parent_port: port_id,
+                });
+                pin_id
+            })
+            .collect();
+        ports.push(ComplexBlockPort {
+            name: port_name,
+            parent_complex_block: node_id,
+            pins: pin_ids,
+        });
         match port {
-            Port::Input(_)  => nodes[node_id].input_ports.push(port_id),
+            Port::Input(_) => nodes[node_id].input_ports.push(port_id),
             Port::Output(_) => nodes[node_id].output_ports.push(port_id),
-            Port::Clock(_)  => nodes[node_id].clock_ports.push(port_id),
+            Port::Clock(_) => nodes[node_id].clock_ports.push(port_id),
         }
     }
 
     // Collect (mode_id, child pb_types, interconnects) so we can build modes child-first.
     // A pb_type has either explicit modes or direct pb_type children (implicit default mode).
-    let mode_sources: Vec<(ComplexBlockModeId, &[PBType], &[Interconnect])> = if !pb_type.modes.is_empty() {
-        pb_type.modes.iter().map(|mode| {
+    let mode_sources: Vec<(ComplexBlockModeId, &[PBType], &[Interconnect])> =
+        if !pb_type.modes.is_empty() {
+            pb_type
+                .modes
+                .iter()
+                .map(|mode| {
+                    let mode_id = ComplexBlockModeId(modes.len());
+                    modes.push(ComplexBlockMode {
+                        parent_complex_block: node_id,
+                        children_complex_blocks: Vec::new(),
+                        interconnect: Vec::new(),
+                    });
+                    (
+                        mode_id,
+                        mode.pb_types.as_slice(),
+                        mode.interconnects.as_slice(),
+                    )
+                })
+                .collect()
+        } else if !pb_type.pb_types.is_empty() {
+            // Implicit single default mode for pb_types with direct children but no named modes.
             let mode_id = ComplexBlockModeId(modes.len());
             modes.push(ComplexBlockMode {
                 parent_complex_block: node_id,
                 children_complex_blocks: Vec::new(),
                 interconnect: Vec::new(),
             });
-            (mode_id, mode.pb_types.as_slice(), mode.interconnects.as_slice())
-        }).collect()
-    } else if !pb_type.pb_types.is_empty() {
-        // Implicit single default mode for pb_types with direct children but no named modes.
-        let mode_id = ComplexBlockModeId(modes.len());
-        modes.push(ComplexBlockMode {
-            parent_complex_block: node_id,
-            children_complex_blocks: Vec::new(),
-            interconnect: Vec::new(),
-        });
-        vec![(mode_id, pb_type.pb_types.as_slice(), pb_type.interconnects.as_slice())]
-    } else {
-        Vec::new()
-    };
+            vec![(
+                mode_id,
+                pb_type.pb_types.as_slice(),
+                pb_type.interconnects.as_slice(),
+            )]
+        } else {
+            Vec::new()
+        };
 
     // Recurse into children and fill in each mode's children list.
     // Each child pb_type is instantiated num_pb times, producing independent nodes.
@@ -173,9 +202,13 @@ fn add_pb_type_recursive(
         let mut children_by_name: HashMap<String, Vec<ComplexBlockNodeId>> = HashMap::new();
         for child in children {
             for _ in 0..child.num_pb as usize {
-                let child_id = add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins)?;
+                let child_id =
+                    add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins)?;
                 child_ids.push(child_id);
-                children_by_name.entry(child.name.clone()).or_default().push(child_id);
+                children_by_name
+                    .entry(child.name.clone())
+                    .or_default()
+                    .push(child_id);
             }
         }
         let mut mode_nets: Vec<ComplexBlockNet> = Vec::new();
@@ -198,12 +231,14 @@ fn add_pb_type_recursive(
         nodes[node_id].modes.push(mode_id);
     }
 
-    nodes[node_id].primitive_info = pb_type.blif_model.as_ref().map(|blif_model| {
-        ComplexBlockPrimitiveInfo {
-            blif_model: blif_model.clone(),
-            class: pb_type.class.clone(),
-        }
-    });
+    nodes[node_id].primitive_info =
+        pb_type
+            .blif_model
+            .as_ref()
+            .map(|blif_model| ComplexBlockPrimitiveInfo {
+                blif_model: blif_model.clone(),
+                class: pb_type.class.clone(),
+            });
 
     Ok(node_id)
 }
@@ -230,8 +265,15 @@ fn parse_name_with_range(s: &str) -> (&str, Option<(usize, usize)>) {
     }
 }
 
+type PortRef<'a> = (
+    &'a str,
+    Option<(usize, usize)>,
+    &'a str,
+    Option<(usize, usize)>,
+);
+
 // Parses "block[range].port[range]" into (block_name, inst_range, port_name, bit_range).
-fn parse_port_ref(s: &str) -> (&str, Option<(usize, usize)>, &str, Option<(usize, usize)>) {
+fn parse_port_ref(s: &str) -> PortRef<'_> {
     let dot = s.find('.').unwrap_or(s.len());
     let (block_name, inst_range) = parse_name_with_range(&s[..dot]);
     let (port_name, bit_range) = if dot < s.len() {
@@ -265,10 +307,12 @@ fn resolve_pins_for_ref(
         vec![parent_node_id]
     } else {
         match children_by_name.get(block_name) {
-            None => return Err(FPGAArchParseError::PinParsingError(format!(
-                "Unknown block '{}' in interconnect reference '{}'",
-                block_name, ref_str
-            ))),
+            None => {
+                return Err(FPGAArchParseError::PinParsingError(format!(
+                    "Unknown block '{}' in interconnect reference '{}'",
+                    block_name, ref_str
+                )));
+            }
             Some(instances) => match inst_range {
                 None => instances.clone(),
                 Some((a, b)) => {
@@ -278,13 +322,21 @@ fn resolve_pins_for_ref(
                     if hi >= instances.len() {
                         return Err(FPGAArchParseError::PinParsingError(format!(
                             "Instance index {} out of range for block '{}' (has {} instance(s)) in reference '{}'",
-                            hi, block_name, instances.len(), ref_str
+                            hi,
+                            block_name,
+                            instances.len(),
+                            ref_str
                         )));
                     }
                     if a >= b {
-                        (lo..=hi).rev().filter_map(|i| instances.get(i).copied()).collect()
+                        (lo..=hi)
+                            .rev()
+                            .filter_map(|i| instances.get(i).copied())
+                            .collect()
                     } else {
-                        (lo..=hi).filter_map(|i| instances.get(i).copied()).collect()
+                        (lo..=hi)
+                            .filter_map(|i| instances.get(i).copied())
+                            .collect()
                     }
                 }
             },
@@ -296,15 +348,19 @@ fn resolve_pins_for_ref(
     let mut result = Vec::new();
     for nid in node_ids {
         let node = &nodes[nid.0];
-        let port_id = node.input_ports.iter()
+        let port_id = node
+            .input_ports
+            .iter()
             .chain(node.output_ports.iter())
             .chain(node.clock_ports.iter())
             .find(|&&pid| ports[pid.0].name == port_name)
             .copied();
-        let pid = port_id.ok_or_else(|| FPGAArchParseError::PinParsingError(format!(
-            "Port '{}' not found on block '{}' in reference '{}'",
-            port_name, block_name, ref_str
-        )))?;
+        let pid = port_id.ok_or_else(|| {
+            FPGAArchParseError::PinParsingError(format!(
+                "Port '{}' not found on block '{}' in reference '{}'",
+                port_name, block_name, ref_str
+            ))
+        })?;
         let port_pins = &ports[pid.0].pins;
         match bit_range {
             None => result.extend_from_slice(port_pins),
@@ -314,17 +370,17 @@ fn resolve_pins_for_ref(
                 if hi >= port_pins.len() {
                     return Err(FPGAArchParseError::PinParsingError(format!(
                         "Bit index {} out of range for port '{}' on block '{}' (has {} pin(s)) in reference '{}'",
-                        hi, port_name, block_name, port_pins.len(), ref_str
+                        hi,
+                        port_name,
+                        block_name,
+                        port_pins.len(),
+                        ref_str
                     )));
                 }
                 if a >= b {
-                    for i in (lo..=hi).rev() {
-                        result.push(port_pins[i]);
-                    }
+                    result.extend(port_pins[lo..=hi].iter().rev().copied());
                 } else {
-                    for i in lo..=hi {
-                        result.push(port_pins[i]);
-                    }
+                    result.extend_from_slice(&port_pins[lo..=hi]);
                 }
             }
         }
@@ -343,8 +399,8 @@ fn build_interconnect_node_and_nets(
     pins: &mut Vec<ComplexBlockPin>,
 ) -> Result<(ComplexBlockNodeId, Vec<ComplexBlockNet>), FPGAArchParseError> {
     let class = match interconnect.interconnect_type {
-        InterconnectType::Direct   => PBTypeClass::InterconnectDirect,
-        InterconnectType::Mux      => PBTypeClass::InterconnectMux,
+        InterconnectType::Direct => PBTypeClass::InterconnectDirect,
+        InterconnectType::Mux => PBTypeClass::InterconnectMux,
         InterconnectType::Complete => PBTypeClass::InterconnectComplete,
     };
 
@@ -355,13 +411,23 @@ fn build_interconnect_node_and_nets(
     let mut input_pin_groups: Vec<Vec<ComplexBlockPinId>> = Vec::new();
     for &group in &input_groups {
         input_pin_groups.push(resolve_pins_for_ref(
-            group, parent_pb_name, parent_node_id, children_by_name, nodes, ports,
+            group,
+            parent_pb_name,
+            parent_node_id,
+            children_by_name,
+            nodes,
+            ports,
         )?);
     }
     let mut output_pins: Vec<ComplexBlockPinId> = Vec::new();
     for token in interconnect.output.split_whitespace() {
         output_pins.extend(resolve_pins_for_ref(
-            token, parent_pb_name, parent_node_id, children_by_name, nodes, ports,
+            token,
+            parent_pb_name,
+            parent_node_id,
+            children_by_name,
+            nodes,
+            ports,
         )?);
     }
 
@@ -387,16 +453,24 @@ fn build_interconnect_node_and_nets(
         let mut port_pin_ids = Vec::new();
         for source_pin in source_pins {
             let inter_pin = ComplexBlockPinId(pins.len());
-            pins.push(ComplexBlockPin { parent_port: port_id });
+            pins.push(ComplexBlockPin {
+                parent_port: port_id,
+            });
             port_pin_ids.push(inter_pin);
-            nets.push(ComplexBlockNet { pins: vec![source_pin, inter_pin] });
+            nets.push(ComplexBlockNet {
+                pins: vec![source_pin, inter_pin],
+            });
         }
         let port_name = if num_input_groups == 1 {
             "input".to_string()
         } else {
             format!("input_{}", group_idx)
         };
-        ports.push(ComplexBlockPort { name: port_name, parent_complex_block: node_id, pins: port_pin_ids });
+        ports.push(ComplexBlockPort {
+            name: port_name,
+            parent_complex_block: node_id,
+            pins: port_pin_ids,
+        });
         input_port_ids.push(port_id);
     }
 
@@ -405,9 +479,13 @@ fn build_interconnect_node_and_nets(
     let mut output_pin_ids = Vec::new();
     for sink_pin in output_pins {
         let inter_pin = ComplexBlockPinId(pins.len());
-        pins.push(ComplexBlockPin { parent_port: output_port_id });
+        pins.push(ComplexBlockPin {
+            parent_port: output_port_id,
+        });
         output_pin_ids.push(inter_pin);
-        nets.push(ComplexBlockNet { pins: vec![inter_pin, sink_pin] });
+        nets.push(ComplexBlockNet {
+            pins: vec![inter_pin, sink_pin],
+        });
     }
     ports.push(ComplexBlockPort {
         name: "output".to_string(),

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -1,7 +1,7 @@
 
 use std::ops::{Index, IndexMut};
 
-use crate::{FPGAArchParseError, PBType, PBTypeClass, Port};
+use crate::{FPGAArchParseError, Interconnect, InterconnectType, PBType, PBTypeClass, Port};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ComplexBlockNodeId(usize);
@@ -141,9 +141,9 @@ fn add_pb_type_recursive(
         }
     }
 
-    // Collect (mode_id, child pb_types) so we can build modes child-first.
+    // Collect (mode_id, child pb_types, interconnects) so we can build modes child-first.
     // A pb_type has either explicit modes or direct pb_type children (implicit default mode).
-    let mode_sources: Vec<(ComplexBlockModeId, &Vec<PBType>)> = if !pb_type.modes.is_empty() {
+    let mode_sources: Vec<(ComplexBlockModeId, &[PBType], &[Interconnect])> = if !pb_type.modes.is_empty() {
         pb_type.modes.iter().map(|mode| {
             let mode_id = ComplexBlockModeId(modes.len());
             modes.push(ComplexBlockMode {
@@ -151,7 +151,7 @@ fn add_pb_type_recursive(
                 children_complex_blocks: Vec::new(),
                 interconnect: Vec::new(),
             });
-            (mode_id, &mode.pb_types)
+            (mode_id, mode.pb_types.as_slice(), mode.interconnects.as_slice())
         }).collect()
     } else if !pb_type.pb_types.is_empty() {
         // Implicit single default mode for pb_types with direct children but no named modes.
@@ -161,18 +161,21 @@ fn add_pb_type_recursive(
             children_complex_blocks: Vec::new(),
             interconnect: Vec::new(),
         });
-        vec![(mode_id, &pb_type.pb_types)]
+        vec![(mode_id, pb_type.pb_types.as_slice(), pb_type.interconnects.as_slice())]
     } else {
         Vec::new()
     };
 
     // Recurse into children and fill in each mode's children list.
     let mut mode_ids: Vec<ComplexBlockModeId> = Vec::new();
-    for (mode_id, children) in mode_sources {
-        let child_ids: Vec<ComplexBlockNodeId> = children
+    for (mode_id, children, interconnects) in mode_sources {
+        let mut child_ids: Vec<ComplexBlockNodeId> = children
             .iter()
             .map(|child| add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins))
             .collect();
+        for interconnect in interconnects {
+            child_ids.push(add_interconnect(interconnect, mode_id, nodes, ports));
+        }
         modes[mode_id].children_complex_blocks = child_ids;
         mode_ids.push(mode_id);
     }
@@ -187,6 +190,51 @@ fn add_pb_type_recursive(
             class: pb_type.class.clone(),
         }
     });
+
+    node_id
+}
+
+fn add_interconnect(
+    interconnect: &Interconnect,
+    parent_mode: ComplexBlockModeId,
+    nodes: &mut Vec<ComplexBlockNode>,
+    ports: &mut Vec<ComplexBlockPort>,
+) -> ComplexBlockNodeId {
+    let node_id = ComplexBlockNodeId(nodes.len());
+    nodes.push(ComplexBlockNode {
+        parent_mode: Some(parent_mode),
+        modes: Vec::new(),
+        primitive_info: None,
+        input_ports: Vec::new(),
+        output_ports: Vec::new(),
+        clock_ports: Vec::new(),
+    });
+
+    let class = match interconnect.interconnect_type {
+        InterconnectType::Direct   => PBTypeClass::InterconnectDirect,
+        InterconnectType::Mux      => PBTypeClass::InterconnectMux,
+        InterconnectType::Complete => PBTypeClass::InterconnectComplete,
+    };
+
+    // Mux has 2 input ports; direct and complete have 1. All types have 1 output port.
+    let num_input_ports = match interconnect.interconnect_type {
+        InterconnectType::Mux => 2,
+        _                     => 1,
+    };
+    let input_port_ids: Vec<ComplexBlockPortId> = (0..num_input_ports).map(|_| {
+        let port_id = ComplexBlockPortId(ports.len());
+        ports.push(ComplexBlockPort { parent_complex_block: node_id, pins: Vec::new() });
+        port_id
+    }).collect();
+    let output_port_id = ComplexBlockPortId(ports.len());
+    ports.push(ComplexBlockPort { parent_complex_block: node_id, pins: Vec::new() });
+
+    nodes[node_id].primitive_info = Some(ComplexBlockPrimitiveInfo {
+        blif_model: interconnect.name.clone(),
+        class,
+    });
+    nodes[node_id].input_ports = input_port_ids;
+    nodes[node_id].output_ports = vec![output_port_id];
 
     node_id
 }

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -1,7 +1,7 @@
 
 use std::ops::{Index, IndexMut};
 
-use crate::{FPGAArchParseError, PBType, PBTypeClass};
+use crate::{FPGAArchParseError, PBType, PBTypeClass, Port};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ComplexBlockNodeId(usize);
@@ -58,6 +58,7 @@ pub struct ComplexBlockNode {
 }
 
 pub struct ComplexBlockPort {
+    pub parent_complex_block: ComplexBlockNodeId,
     pub pins: Vec<ComplexBlockPinId>,
 }
 
@@ -83,15 +84,17 @@ pub fn build_complex_block_graph(root_pb_type: &PBType) -> Result<ComplexBlockGr
     // and then constructing their parents.
     let mut nodes: Vec<ComplexBlockNode> = Vec::new();
     let mut modes: Vec<ComplexBlockMode> = Vec::new();
+    let mut ports: Vec<ComplexBlockPort> = Vec::new();
+    let mut pins: Vec<ComplexBlockPin> = Vec::new();
 
-    let root_id = add_pb_type_recursive(root_pb_type, None, &mut nodes, &mut modes);
+    let root_id = add_pb_type_recursive(root_pb_type, None, &mut nodes, &mut modes, &mut ports, &mut pins);
 
     Ok(ComplexBlockGraph {
         root_complex_block_node: root_id,
         complex_block_nodes: nodes,
         complex_block_modes: modes,
-        complex_block_ports: Vec::new(),
-        complex_block_pins: Vec::new(),
+        complex_block_ports: ports,
+        complex_block_pins: pins,
     })
 }
 
@@ -100,6 +103,8 @@ fn add_pb_type_recursive(
     parent_mode: Option<ComplexBlockModeId>,
     nodes: &mut Vec<ComplexBlockNode>,
     modes: &mut Vec<ComplexBlockMode>,
+    ports: &mut Vec<ComplexBlockPort>,
+    pins: &mut Vec<ComplexBlockPin>,
 ) -> ComplexBlockNodeId {
     // Reserve the node slot so its ID is known before processing children.
     let node_id = ComplexBlockNodeId(nodes.len());
@@ -111,6 +116,30 @@ fn add_pb_type_recursive(
         output_ports: Vec::new(),
         clock_ports: Vec::new(),
     });
+
+    // Build ports and pins for this node.
+    let mut input_port_ids: Vec<ComplexBlockPortId> = Vec::new();
+    let mut output_port_ids: Vec<ComplexBlockPortId> = Vec::new();
+    let mut clock_port_ids: Vec<ComplexBlockPortId> = Vec::new();
+    for port in &pb_type.ports {
+        let num_pins = match port {
+            Port::Input(p) => p.num_pins,
+            Port::Output(p) => p.num_pins,
+            Port::Clock(p) => p.num_pins,
+        };
+        let port_id = ComplexBlockPortId(ports.len());
+        let pin_ids: Vec<ComplexBlockPinId> = (0..num_pins as usize).map(|_| {
+            let pin_id = ComplexBlockPinId(pins.len());
+            pins.push(ComplexBlockPin { parent_port: port_id });
+            pin_id
+        }).collect();
+        ports.push(ComplexBlockPort { parent_complex_block: node_id, pins: pin_ids });
+        match port {
+            Port::Input(_)  => input_port_ids.push(port_id),
+            Port::Output(_) => output_port_ids.push(port_id),
+            Port::Clock(_)  => clock_port_ids.push(port_id),
+        }
+    }
 
     // Collect (mode_id, child pb_types) so we can build modes child-first.
     // A pb_type has either explicit modes or direct pb_type children (implicit default mode).
@@ -142,13 +171,16 @@ fn add_pb_type_recursive(
     for (mode_id, children) in mode_sources {
         let child_ids: Vec<ComplexBlockNodeId> = children
             .iter()
-            .map(|child| add_pb_type_recursive(child, Some(mode_id), nodes, modes))
+            .map(|child| add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins))
             .collect();
         modes[mode_id].children_complex_blocks = child_ids;
         mode_ids.push(mode_id);
     }
 
     nodes[node_id].modes = mode_ids;
+    nodes[node_id].input_ports = input_port_ids;
+    nodes[node_id].output_ports = output_port_ids;
+    nodes[node_id].clock_ports = clock_port_ids;
     nodes[node_id].primitive_info = pb_type.blif_model.as_ref().map(|blif_model| {
         ComplexBlockPrimitiveInfo {
             blif_model: blif_model.clone(),

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -1,0 +1,80 @@
+
+use std::ops::Index;
+
+use crate::PBTypeClass;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ComplexBlockNodeId(usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ComplexBlockPortId(usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ComplexBlockPinId(usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ComplexBlockModeId(usize);
+
+macro_rules! impl_vec_index {
+    ($id:ty, $item:ty) => {
+        impl Index<$id> for Vec<$item> {
+            type Output = $item;
+            fn index(&self, id: $id) -> &Self::Output {
+                &self[id.0]
+            }
+        }
+    };
+}
+
+impl_vec_index!(ComplexBlockNodeId, ComplexBlockNode);
+impl_vec_index!(ComplexBlockPortId, ComplexBlockPort);
+impl_vec_index!(ComplexBlockPinId, ComplexBlockPin);
+impl_vec_index!(ComplexBlockModeId, ComplexBlockMode);
+
+pub struct ComplexBlockMode {
+    // FIXME: Primitives probably would make sense as a specialization of the mode.
+    pub parent_complex_block: ComplexBlockNodeId,
+    pub children_complex_blocks: Vec<ComplexBlockNodeId>,
+    pub interconnect: Vec<ComplexBlockNet>,
+}
+
+pub struct ComplexBlockPrimitiveInfo {
+    pub blif_model: String,
+    pub class: PBTypeClass,
+}
+
+pub struct ComplexBlockNode {
+    pub parent_mode: ComplexBlockModeId,
+    pub modes: Vec<ComplexBlockModeId>,
+    pub primitive_info: Option<ComplexBlockPrimitiveInfo>,
+    pub input_ports: Vec<ComplexBlockPortId>,
+    pub output_ports: Vec<ComplexBlockPortId>,
+    pub clock_ports: Vec<ComplexBlockPortId>,
+}
+
+pub struct ComplexBlockPort {
+    pub pins: Vec<ComplexBlockPinId>,
+}
+
+pub struct ComplexBlockPin {
+    pub parent_port: ComplexBlockPortId,
+}
+
+pub struct ComplexBlockNet {
+    pub pins: Vec<ComplexBlockPinId>,
+}
+
+pub struct ComplexBlockGraph {
+    pub root_complex_block_node: ComplexBlockNodeId,
+
+    complex_block_nodes: Vec<ComplexBlockNode>,
+    complex_block_modes: Vec<ComplexBlockMode>,
+    complex_block_ports: Vec<ComplexBlockPort>,
+    complex_block_pins: Vec<ComplexBlockPin>,
+}
+
+impl ComplexBlockGraph {
+    pub fn get_complex_block(&self, complex_block_node_id: ComplexBlockNodeId) -> &ComplexBlockNode {
+        &self.complex_block_nodes[complex_block_node_id]
+    }
+}

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -167,12 +167,15 @@ fn add_pb_type_recursive(
     };
 
     // Recurse into children and fill in each mode's children list.
+    // Each child pb_type is instantiated num_pb times, producing independent nodes.
     let mut mode_ids: Vec<ComplexBlockModeId> = Vec::new();
     for (mode_id, children, interconnects) in mode_sources {
-        let mut child_ids: Vec<ComplexBlockNodeId> = children
-            .iter()
-            .map(|child| add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins))
-            .collect();
+        let mut child_ids: Vec<ComplexBlockNodeId> = Vec::new();
+        for child in children {
+            for _ in 0..child.num_pb as usize {
+                child_ids.push(add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins));
+            }
+        }
         for interconnect in interconnects {
             child_ids.push(add_interconnect(interconnect, mode_id, nodes, ports));
         }

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -1,4 +1,5 @@
 
+use std::collections::HashMap;
 use std::ops::{Index, IndexMut};
 
 use crate::{FPGAArchParseError, Interconnect, InterconnectType, PBType, PBTypeClass, Port};
@@ -37,7 +38,6 @@ impl_vec_index!(ComplexBlockPinId, ComplexBlockPin);
 impl_vec_index!(ComplexBlockModeId, ComplexBlockMode);
 
 pub struct ComplexBlockMode {
-    // FIXME: Primitives probably would make sense as a specialization of the mode.
     pub parent_complex_block: ComplexBlockNodeId,
     pub children_complex_blocks: Vec<ComplexBlockNodeId>,
     pub interconnect: Vec<ComplexBlockNet>,
@@ -49,6 +49,7 @@ pub struct ComplexBlockPrimitiveInfo {
 }
 
 pub struct ComplexBlockNode {
+    pub name: String,
     pub parent_mode: Option<ComplexBlockModeId>,
     pub modes: Vec<ComplexBlockModeId>,
     pub primitive_info: Option<ComplexBlockPrimitiveInfo>,
@@ -58,6 +59,7 @@ pub struct ComplexBlockNode {
 }
 
 pub struct ComplexBlockPort {
+    pub name: String,
     pub parent_complex_block: ComplexBlockNodeId,
     pub pins: Vec<ComplexBlockPinId>,
 }
@@ -87,7 +89,7 @@ pub fn build_complex_block_graph(root_pb_type: &PBType) -> Result<ComplexBlockGr
     let mut ports: Vec<ComplexBlockPort> = Vec::new();
     let mut pins: Vec<ComplexBlockPin> = Vec::new();
 
-    let root_id = add_pb_type_recursive(root_pb_type, None, &mut nodes, &mut modes, &mut ports, &mut pins);
+    let root_id = add_pb_type_recursive(root_pb_type, None, &mut nodes, &mut modes, &mut ports, &mut pins)?;
 
     Ok(ComplexBlockGraph {
         root_complex_block_node: root_id,
@@ -105,10 +107,11 @@ fn add_pb_type_recursive(
     modes: &mut Vec<ComplexBlockMode>,
     ports: &mut Vec<ComplexBlockPort>,
     pins: &mut Vec<ComplexBlockPin>,
-) -> ComplexBlockNodeId {
+) -> Result<ComplexBlockNodeId, FPGAArchParseError> {
     // Reserve the node slot so its ID is known before processing children.
     let node_id = ComplexBlockNodeId(nodes.len());
     nodes.push(ComplexBlockNode {
+        name: pb_type.name.clone(),
         parent_mode,
         modes: Vec::new(),
         primitive_info: None,
@@ -122,10 +125,10 @@ fn add_pb_type_recursive(
     let mut output_port_ids: Vec<ComplexBlockPortId> = Vec::new();
     let mut clock_port_ids: Vec<ComplexBlockPortId> = Vec::new();
     for port in &pb_type.ports {
-        let num_pins = match port {
-            Port::Input(p) => p.num_pins,
-            Port::Output(p) => p.num_pins,
-            Port::Clock(p) => p.num_pins,
+        let (port_name, num_pins) = match port {
+            Port::Input(p)  => (p.name.clone(), p.num_pins),
+            Port::Output(p) => (p.name.clone(), p.num_pins),
+            Port::Clock(p)  => (p.name.clone(), p.num_pins),
         };
         let port_id = ComplexBlockPortId(ports.len());
         let pin_ids: Vec<ComplexBlockPinId> = (0..num_pins as usize).map(|_| {
@@ -133,13 +136,18 @@ fn add_pb_type_recursive(
             pins.push(ComplexBlockPin { parent_port: port_id });
             pin_id
         }).collect();
-        ports.push(ComplexBlockPort { parent_complex_block: node_id, pins: pin_ids });
+        ports.push(ComplexBlockPort { name: port_name, parent_complex_block: node_id, pins: pin_ids });
         match port {
             Port::Input(_)  => input_port_ids.push(port_id),
             Port::Output(_) => output_port_ids.push(port_id),
             Port::Clock(_)  => clock_port_ids.push(port_id),
         }
     }
+
+    // Write ports back to the node now so interconnect pin resolution can find them.
+    nodes[node_id].input_ports = input_port_ids.clone();
+    nodes[node_id].output_ports = output_port_ids.clone();
+    nodes[node_id].clock_ports = clock_port_ids.clone();
 
     // Collect (mode_id, child pb_types, interconnects) so we can build modes child-first.
     // A pb_type has either explicit modes or direct pb_type children (implicit default mode).
@@ -171,22 +179,35 @@ fn add_pb_type_recursive(
     let mut mode_ids: Vec<ComplexBlockModeId> = Vec::new();
     for (mode_id, children, interconnects) in mode_sources {
         let mut child_ids: Vec<ComplexBlockNodeId> = Vec::new();
+        let mut children_by_name: HashMap<String, Vec<ComplexBlockNodeId>> = HashMap::new();
         for child in children {
             for _ in 0..child.num_pb as usize {
-                child_ids.push(add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins));
+                let child_id = add_pb_type_recursive(child, Some(mode_id), nodes, modes, ports, pins)?;
+                child_ids.push(child_id);
+                children_by_name.entry(child.name.clone()).or_default().push(child_id);
             }
         }
+        let mut mode_nets: Vec<ComplexBlockNet> = Vec::new();
         for interconnect in interconnects {
-            child_ids.push(add_interconnect(interconnect, mode_id, nodes, ports));
+            let (inter_id, nets) = build_interconnect_node_and_nets(
+                interconnect,
+                mode_id,
+                node_id,
+                &pb_type.name,
+                &children_by_name,
+                nodes,
+                ports,
+                pins,
+            )?;
+            child_ids.push(inter_id);
+            mode_nets.extend(nets);
         }
         modes[mode_id].children_complex_blocks = child_ids;
+        modes[mode_id].interconnect = mode_nets;
         mode_ids.push(mode_id);
     }
 
     nodes[node_id].modes = mode_ids;
-    nodes[node_id].input_ports = input_port_ids;
-    nodes[node_id].output_ports = output_port_ids;
-    nodes[node_id].clock_ports = clock_port_ids;
     nodes[node_id].primitive_info = pb_type.blif_model.as_ref().map(|blif_model| {
         ComplexBlockPrimitiveInfo {
             blif_model: blif_model.clone(),
@@ -194,18 +215,171 @@ fn add_pb_type_recursive(
         }
     });
 
-    node_id
+    Ok(node_id)
 }
 
-fn add_interconnect(
+// Parses "name", "name[idx]", or "name[high:low]" into (name, range).
+// The range preserves order: (3, 1) means high-to-low, (1, 3) means low-to-high.
+fn parse_name_with_range(s: &str) -> (&str, Option<(usize, usize)>) {
+    match s.find('[') {
+        None => (s, None),
+        Some(open) => {
+            let name = &s[..open];
+            let close = s.find(']').unwrap_or(s.len());
+            let inner = &s[open + 1..close];
+            let range = if let Some(colon) = inner.find(':') {
+                let a: usize = inner[..colon].trim().parse().unwrap_or(0);
+                let b: usize = inner[colon + 1..].trim().parse().unwrap_or(0);
+                (a, b)
+            } else {
+                let a: usize = inner.trim().parse().unwrap_or(0);
+                (a, a)
+            };
+            (name, Some(range))
+        }
+    }
+}
+
+// Parses "block[range].port[range]" into (block_name, inst_range, port_name, bit_range).
+fn parse_port_ref(s: &str) -> (&str, Option<(usize, usize)>, &str, Option<(usize, usize)>) {
+    let dot = s.find('.').unwrap_or(s.len());
+    let (block_name, inst_range) = parse_name_with_range(&s[..dot]);
+    let (port_name, bit_range) = if dot < s.len() {
+        parse_name_with_range(&s[dot + 1..])
+    } else {
+        ("", None)
+    };
+    (block_name, inst_range, port_name, bit_range)
+}
+
+// Resolves a single port-reference token to the ComplexBlockPinIds it names.
+// Preserves the order implied by any ranges (e.g. [3:1] yields pins 3, 2, 1).
+fn resolve_pins_for_ref(
+    ref_str: &str,
+    parent_pb_name: &str,
+    parent_node_id: ComplexBlockNodeId,
+    children_by_name: &HashMap<String, Vec<ComplexBlockNodeId>>,
+    nodes: &[ComplexBlockNode],
+    ports: &[ComplexBlockPort],
+) -> Result<Vec<ComplexBlockPinId>, FPGAArchParseError> {
+    let (block_name, inst_range, port_name, bit_range) = parse_port_ref(ref_str);
+    if port_name.is_empty() {
+        return Err(FPGAArchParseError::PinParsingError(format!(
+            "No port name in reference '{}' (missing '.')",
+            ref_str
+        )));
+    }
+
+    // Collect the node IDs indicated by the block reference.
+    let node_ids: Vec<ComplexBlockNodeId> = if block_name == parent_pb_name {
+        vec![parent_node_id]
+    } else {
+        match children_by_name.get(block_name) {
+            None => return Err(FPGAArchParseError::PinParsingError(format!(
+                "Unknown block '{}' in interconnect reference '{}'",
+                block_name, ref_str
+            ))),
+            Some(instances) => match inst_range {
+                None => instances.clone(),
+                Some((a, b)) => {
+                    let lo = a.min(b);
+                    let hi = a.max(b);
+                    // Validate that all requested indices exist.
+                    if hi >= instances.len() {
+                        return Err(FPGAArchParseError::PinParsingError(format!(
+                            "Instance index {} out of range for block '{}' (has {} instance(s)) in reference '{}'",
+                            hi, block_name, instances.len(), ref_str
+                        )));
+                    }
+                    if a >= b {
+                        (lo..=hi).rev().filter_map(|i| instances.get(i).copied()).collect()
+                    } else {
+                        (lo..=hi).filter_map(|i| instances.get(i).copied()).collect()
+                    }
+                }
+            },
+        }
+    };
+
+    // For each node find the named port, then collect the indicated pins.
+    // Use .0 for plain slice indexing since the custom Index trait is Vec-only.
+    let mut result = Vec::new();
+    for nid in node_ids {
+        let node = &nodes[nid.0];
+        let port_id = node.input_ports.iter()
+            .chain(node.output_ports.iter())
+            .chain(node.clock_ports.iter())
+            .find(|&&pid| ports[pid.0].name == port_name)
+            .copied();
+        let pid = port_id.ok_or_else(|| FPGAArchParseError::PinParsingError(format!(
+            "Port '{}' not found on block '{}' in reference '{}'",
+            port_name, block_name, ref_str
+        )))?;
+        let port_pins = &ports[pid.0].pins;
+        match bit_range {
+            None => result.extend_from_slice(port_pins),
+            Some((a, b)) => {
+                let lo = a.min(b);
+                let hi = a.max(b);
+                if hi >= port_pins.len() {
+                    return Err(FPGAArchParseError::PinParsingError(format!(
+                        "Bit index {} out of range for port '{}' on block '{}' (has {} pin(s)) in reference '{}'",
+                        hi, port_name, block_name, port_pins.len(), ref_str
+                    )));
+                }
+                if a >= b {
+                    for i in (lo..=hi).rev() {
+                        result.push(port_pins[i]);
+                    }
+                } else {
+                    for i in lo..=hi {
+                        result.push(port_pins[i]);
+                    }
+                }
+            }
+        }
+    }
+    Ok(result)
+}
+
+fn build_interconnect_node_and_nets(
     interconnect: &Interconnect,
-    parent_mode: ComplexBlockModeId,
+    parent_mode_id: ComplexBlockModeId,
+    parent_node_id: ComplexBlockNodeId,
+    parent_pb_name: &str,
+    children_by_name: &HashMap<String, Vec<ComplexBlockNodeId>>,
     nodes: &mut Vec<ComplexBlockNode>,
     ports: &mut Vec<ComplexBlockPort>,
-) -> ComplexBlockNodeId {
+    pins: &mut Vec<ComplexBlockPin>,
+) -> Result<(ComplexBlockNodeId, Vec<ComplexBlockNet>), FPGAArchParseError> {
+    let class = match interconnect.interconnect_type {
+        InterconnectType::Direct   => PBTypeClass::InterconnectDirect,
+        InterconnectType::Mux      => PBTypeClass::InterconnectMux,
+        InterconnectType::Complete => PBTypeClass::InterconnectComplete,
+    };
+
+    // Resolve all pin references before mutating nodes/ports.
+    // Both input and output may contain multiple whitespace-separated port references
+    // (e.g. complete interconnects can fan out to multiple output ports).
+    let input_groups: Vec<&str> = interconnect.input.split_whitespace().collect();
+    let mut input_pin_groups: Vec<Vec<ComplexBlockPinId>> = Vec::new();
+    for &group in &input_groups {
+        input_pin_groups.push(resolve_pins_for_ref(
+            group, parent_pb_name, parent_node_id, children_by_name, nodes, ports,
+        )?);
+    }
+    let mut output_pins: Vec<ComplexBlockPinId> = Vec::new();
+    for token in interconnect.output.split_whitespace() {
+        output_pins.extend(resolve_pins_for_ref(
+            token, parent_pb_name, parent_node_id, children_by_name, nodes, ports,
+        )?);
+    }
+
+    // Create the interconnect node.
     let node_id = ComplexBlockNodeId(nodes.len());
     nodes.push(ComplexBlockNode {
-        parent_mode: Some(parent_mode),
+        name: interconnect.name.clone(),
+        parent_mode: Some(parent_mode_id),
         modes: Vec::new(),
         primitive_info: None,
         input_ports: Vec::new(),
@@ -213,24 +387,43 @@ fn add_interconnect(
         clock_ports: Vec::new(),
     });
 
-    let class = match interconnect.interconnect_type {
-        InterconnectType::Direct   => PBTypeClass::InterconnectDirect,
-        InterconnectType::Mux      => PBTypeClass::InterconnectMux,
-        InterconnectType::Complete => PBTypeClass::InterconnectComplete,
-    };
+    let num_input_groups = input_pin_groups.len();
+    let mut input_port_ids: Vec<ComplexBlockPortId> = Vec::new();
+    let mut nets: Vec<ComplexBlockNet> = Vec::new();
 
-    // Mux has 2 input ports; direct and complete have 1. All types have 1 output port.
-    let num_input_ports = match interconnect.interconnect_type {
-        InterconnectType::Mux => 2,
-        _                     => 1,
-    };
-    let input_port_ids: Vec<ComplexBlockPortId> = (0..num_input_ports).map(|_| {
+    // One input port per group; each source pin gets a paired pin on the port and a connecting net.
+    for (group_idx, source_pins) in input_pin_groups.into_iter().enumerate() {
         let port_id = ComplexBlockPortId(ports.len());
-        ports.push(ComplexBlockPort { parent_complex_block: node_id, pins: Vec::new() });
-        port_id
-    }).collect();
+        let mut port_pin_ids = Vec::new();
+        for source_pin in source_pins {
+            let inter_pin = ComplexBlockPinId(pins.len());
+            pins.push(ComplexBlockPin { parent_port: port_id });
+            port_pin_ids.push(inter_pin);
+            nets.push(ComplexBlockNet { pins: vec![source_pin, inter_pin] });
+        }
+        let port_name = if num_input_groups == 1 {
+            "input".to_string()
+        } else {
+            format!("input_{}", group_idx)
+        };
+        ports.push(ComplexBlockPort { name: port_name, parent_complex_block: node_id, pins: port_pin_ids });
+        input_port_ids.push(port_id);
+    }
+
+    // Single output port; each sink pin gets a paired pin on the port and a connecting net.
     let output_port_id = ComplexBlockPortId(ports.len());
-    ports.push(ComplexBlockPort { parent_complex_block: node_id, pins: Vec::new() });
+    let mut output_pin_ids = Vec::new();
+    for sink_pin in output_pins {
+        let inter_pin = ComplexBlockPinId(pins.len());
+        pins.push(ComplexBlockPin { parent_port: output_port_id });
+        output_pin_ids.push(inter_pin);
+        nets.push(ComplexBlockNet { pins: vec![inter_pin, sink_pin] });
+    }
+    ports.push(ComplexBlockPort {
+        name: "output".to_string(),
+        parent_complex_block: node_id,
+        pins: output_pin_ids,
+    });
 
     nodes[node_id].primitive_info = Some(ComplexBlockPrimitiveInfo {
         blif_model: interconnect.name.clone(),
@@ -239,5 +432,5 @@ fn add_interconnect(
     nodes[node_id].input_ports = input_port_ids;
     nodes[node_id].output_ports = vec![output_port_id];
 
-    node_id
+    Ok((node_id, nets))
 }

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -121,9 +121,6 @@ fn add_pb_type_recursive(
     });
 
     // Build ports and pins for this node.
-    let mut input_port_ids: Vec<ComplexBlockPortId> = Vec::new();
-    let mut output_port_ids: Vec<ComplexBlockPortId> = Vec::new();
-    let mut clock_port_ids: Vec<ComplexBlockPortId> = Vec::new();
     for port in &pb_type.ports {
         let (port_name, num_pins) = match port {
             Port::Input(p)  => (p.name.clone(), p.num_pins),
@@ -138,16 +135,11 @@ fn add_pb_type_recursive(
         }).collect();
         ports.push(ComplexBlockPort { name: port_name, parent_complex_block: node_id, pins: pin_ids });
         match port {
-            Port::Input(_)  => input_port_ids.push(port_id),
-            Port::Output(_) => output_port_ids.push(port_id),
-            Port::Clock(_)  => clock_port_ids.push(port_id),
+            Port::Input(_)  => nodes[node_id].input_ports.push(port_id),
+            Port::Output(_) => nodes[node_id].output_ports.push(port_id),
+            Port::Clock(_)  => nodes[node_id].clock_ports.push(port_id),
         }
     }
-
-    // Write ports back to the node now so interconnect pin resolution can find them.
-    nodes[node_id].input_ports = input_port_ids.clone();
-    nodes[node_id].output_ports = output_port_ids.clone();
-    nodes[node_id].clock_ports = clock_port_ids.clone();
 
     // Collect (mode_id, child pb_types, interconnects) so we can build modes child-first.
     // A pb_type has either explicit modes or direct pb_type children (implicit default mode).
@@ -176,7 +168,6 @@ fn add_pb_type_recursive(
 
     // Recurse into children and fill in each mode's children list.
     // Each child pb_type is instantiated num_pb times, producing independent nodes.
-    let mut mode_ids: Vec<ComplexBlockModeId> = Vec::new();
     for (mode_id, children, interconnects) in mode_sources {
         let mut child_ids: Vec<ComplexBlockNodeId> = Vec::new();
         let mut children_by_name: HashMap<String, Vec<ComplexBlockNodeId>> = HashMap::new();
@@ -204,10 +195,9 @@ fn add_pb_type_recursive(
         }
         modes[mode_id].children_complex_blocks = child_ids;
         modes[mode_id].interconnect = mode_nets;
-        mode_ids.push(mode_id);
+        nodes[node_id].modes.push(mode_id);
     }
 
-    nodes[node_id].modes = mode_ids;
     nodes[node_id].primitive_info = pb_type.blif_model.as_ref().map(|blif_model| {
         ComplexBlockPrimitiveInfo {
             blif_model: blif_model.clone(),

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -246,9 +246,11 @@ fn add_pb_type_recursive(
     Ok(node_id)
 }
 
+type NameWithRange<'a> = (&'a str, Option<(usize, usize)>);
+
 // Parses "name", "name[idx]", or "name[high:low]" into (name, range).
 // The range preserves order: (3, 1) means high-to-low, (1, 3) means low-to-high.
-fn parse_name_with_range(s: &str) -> Result<(&str, Option<(usize, usize)>), FPGAArchParseError> {
+fn parse_name_with_range(s: &str) -> Result<NameWithRange<'_>, FPGAArchParseError> {
     match s.find('[') {
         None => Ok((s, None)),
         Some(open) => {
@@ -296,8 +298,8 @@ type PortRef<'a> = (
 // Parses "block[range].port[range]" into (block_name, inst_range, port_name, bit_range).
 fn parse_port_ref(s: &str) -> Result<PortRef<'_>, FPGAArchParseError> {
     let dot = s.find('.').unwrap_or(s.len());
-    let (block_name, inst_range) = parse_name_with_range(&s[..dot])?;
-    let (port_name, bit_range) = if dot < s.len() {
+    let (block_name, inst_range): NameWithRange<'_> = parse_name_with_range(&s[..dot])?;
+    let (port_name, bit_range): NameWithRange<'_> = if dot < s.len() {
         parse_name_with_range(&s[dot + 1..])?
     } else {
         ("", None)

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -248,22 +248,40 @@ fn add_pb_type_recursive(
 
 // Parses "name", "name[idx]", or "name[high:low]" into (name, range).
 // The range preserves order: (3, 1) means high-to-low, (1, 3) means low-to-high.
-fn parse_name_with_range(s: &str) -> (&str, Option<(usize, usize)>) {
+fn parse_name_with_range(s: &str) -> Result<(&str, Option<(usize, usize)>), FPGAArchParseError> {
     match s.find('[') {
-        None => (s, None),
+        None => Ok((s, None)),
         Some(open) => {
             let name = &s[..open];
             let close = s.find(']').unwrap_or(s.len());
             let inner = &s[open + 1..close];
             let range = if let Some(colon) = inner.find(':') {
-                let a: usize = inner[..colon].trim().parse().unwrap_or(0);
-                let b: usize = inner[colon + 1..].trim().parse().unwrap_or(0);
+                let a: usize = inner[..colon].trim().parse().map_err(|_| {
+                    FPGAArchParseError::PinParsingError(format!(
+                        "Failed to parse index '{}' in range expression '[{}]'",
+                        inner[..colon].trim(),
+                        inner
+                    ))
+                })?;
+                let b: usize = inner[colon + 1..].trim().parse().map_err(|_| {
+                    FPGAArchParseError::PinParsingError(format!(
+                        "Failed to parse index '{}' in range expression '[{}]'",
+                        inner[colon + 1..].trim(),
+                        inner
+                    ))
+                })?;
                 (a, b)
             } else {
-                let a: usize = inner.trim().parse().unwrap_or(0);
+                let a: usize = inner.trim().parse().map_err(|_| {
+                    FPGAArchParseError::PinParsingError(format!(
+                        "Failed to parse index '{}' in '[{}]'",
+                        inner.trim(),
+                        inner
+                    ))
+                })?;
                 (a, a)
             };
-            (name, Some(range))
+            Ok((name, Some(range)))
         }
     }
 }
@@ -276,15 +294,15 @@ type PortRef<'a> = (
 );
 
 // Parses "block[range].port[range]" into (block_name, inst_range, port_name, bit_range).
-fn parse_port_ref(s: &str) -> PortRef<'_> {
+fn parse_port_ref(s: &str) -> Result<PortRef<'_>, FPGAArchParseError> {
     let dot = s.find('.').unwrap_or(s.len());
-    let (block_name, inst_range) = parse_name_with_range(&s[..dot]);
+    let (block_name, inst_range) = parse_name_with_range(&s[..dot])?;
     let (port_name, bit_range) = if dot < s.len() {
-        parse_name_with_range(&s[dot + 1..])
+        parse_name_with_range(&s[dot + 1..])?
     } else {
         ("", None)
     };
-    (block_name, inst_range, port_name, bit_range)
+    Ok((block_name, inst_range, port_name, bit_range))
 }
 
 // Resolves a single port-reference token to the ComplexBlockPinIds it names.
@@ -297,7 +315,7 @@ fn resolve_pins_for_ref(
     nodes: &[ComplexBlockNode],
     ports: &[ComplexBlockPort],
 ) -> Result<Vec<ComplexBlockPinId>, FPGAArchParseError> {
-    let (block_name, inst_range, port_name, bit_range) = parse_port_ref(ref_str);
+    let (block_name, inst_range, port_name, bit_range) = parse_port_ref(ref_str)?;
     if port_name.is_empty() {
         return Err(FPGAArchParseError::PinParsingError(format!(
             "No port name in reference '{}' (missing '.')",
@@ -331,7 +349,7 @@ fn resolve_pins_for_ref(
                             ref_str
                         )));
                     }
-                    if a >= b {
+                    if a > b {
                         (lo..=hi)
                             .rev()
                             .filter_map(|i| instances.get(i).copied())
@@ -380,7 +398,7 @@ fn resolve_pins_for_ref(
                         ref_str
                     )));
                 }
-                if a >= b {
+                if a > b {
                     result.extend(port_pins[lo..=hi].iter().rev().copied());
                 } else {
                     result.extend_from_slice(&port_pins[lo..=hi]);

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -137,7 +137,7 @@ fn add_pb_type_recursive(
             Port::Clock(p) => (p.name.clone(), p.num_pins),
         };
         let port_id = ComplexBlockPortId(ports.len());
-        let pin_ids: Vec<ComplexBlockPinId> = (0..num_pins as usize)
+        let pin_ids: Vec<ComplexBlockPinId> = (0..num_pins)
             .map(|_| {
                 let pin_id = ComplexBlockPinId(pins.len());
                 pins.push(ComplexBlockPin {

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -1,7 +1,7 @@
 
-use std::ops::Index;
+use std::ops::{Index, IndexMut};
 
-use crate::PBTypeClass;
+use crate::{FPGAArchParseError, PBType, PBTypeClass};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ComplexBlockNodeId(usize);
@@ -21,6 +21,11 @@ macro_rules! impl_vec_index {
             type Output = $item;
             fn index(&self, id: $id) -> &Self::Output {
                 &self[id.0]
+            }
+        }
+        impl IndexMut<$id> for Vec<$item> {
+            fn index_mut(&mut self, id: $id) -> &mut Self::Output {
+                &mut self[id.0]
             }
         }
     };
@@ -44,7 +49,7 @@ pub struct ComplexBlockPrimitiveInfo {
 }
 
 pub struct ComplexBlockNode {
-    pub parent_mode: ComplexBlockModeId,
+    pub parent_mode: Option<ComplexBlockModeId>,
     pub modes: Vec<ComplexBlockModeId>,
     pub primitive_info: Option<ComplexBlockPrimitiveInfo>,
     pub input_ports: Vec<ComplexBlockPortId>,
@@ -73,8 +78,83 @@ pub struct ComplexBlockGraph {
     complex_block_pins: Vec<ComplexBlockPin>,
 }
 
-impl ComplexBlockGraph {
-    pub fn get_complex_block(&self, complex_block_node_id: ComplexBlockNodeId) -> &ComplexBlockNode {
-        &self.complex_block_nodes[complex_block_node_id]
+pub fn build_complex_block_graph(root_pb_type: &PBType) -> Result<ComplexBlockGraph, FPGAArchParseError> {
+    // Traverse the pb-type heirarchy using a child-first-order traversal, building the children complex blocks first
+    // and then constructing their parents.
+    let mut nodes: Vec<ComplexBlockNode> = Vec::new();
+    let mut modes: Vec<ComplexBlockMode> = Vec::new();
+
+    let root_id = add_pb_type_recursive(root_pb_type, None, &mut nodes, &mut modes);
+
+    Ok(ComplexBlockGraph {
+        root_complex_block_node: root_id,
+        complex_block_nodes: nodes,
+        complex_block_modes: modes,
+        complex_block_ports: Vec::new(),
+        complex_block_pins: Vec::new(),
+    })
+}
+
+fn add_pb_type_recursive(
+    pb_type: &PBType,
+    parent_mode: Option<ComplexBlockModeId>,
+    nodes: &mut Vec<ComplexBlockNode>,
+    modes: &mut Vec<ComplexBlockMode>,
+) -> ComplexBlockNodeId {
+    // Reserve the node slot so its ID is known before processing children.
+    let node_id = ComplexBlockNodeId(nodes.len());
+    nodes.push(ComplexBlockNode {
+        parent_mode,
+        modes: Vec::new(),
+        primitive_info: None,
+        input_ports: Vec::new(),
+        output_ports: Vec::new(),
+        clock_ports: Vec::new(),
+    });
+
+    // Collect (mode_id, child pb_types) so we can build modes child-first.
+    // A pb_type has either explicit modes or direct pb_type children (implicit default mode).
+    let mode_sources: Vec<(ComplexBlockModeId, &Vec<PBType>)> = if !pb_type.modes.is_empty() {
+        pb_type.modes.iter().map(|mode| {
+            let mode_id = ComplexBlockModeId(modes.len());
+            modes.push(ComplexBlockMode {
+                parent_complex_block: node_id,
+                children_complex_blocks: Vec::new(),
+                interconnect: Vec::new(),
+            });
+            (mode_id, &mode.pb_types)
+        }).collect()
+    } else if !pb_type.pb_types.is_empty() {
+        // Implicit single default mode for pb_types with direct children but no named modes.
+        let mode_id = ComplexBlockModeId(modes.len());
+        modes.push(ComplexBlockMode {
+            parent_complex_block: node_id,
+            children_complex_blocks: Vec::new(),
+            interconnect: Vec::new(),
+        });
+        vec![(mode_id, &pb_type.pb_types)]
+    } else {
+        Vec::new()
+    };
+
+    // Recurse into children and fill in each mode's children list.
+    let mut mode_ids: Vec<ComplexBlockModeId> = Vec::new();
+    for (mode_id, children) in mode_sources {
+        let child_ids: Vec<ComplexBlockNodeId> = children
+            .iter()
+            .map(|child| add_pb_type_recursive(child, Some(mode_id), nodes, modes))
+            .collect();
+        modes[mode_id].children_complex_blocks = child_ids;
+        mode_ids.push(mode_id);
     }
+
+    nodes[node_id].modes = mode_ids;
+    nodes[node_id].primitive_info = pb_type.blif_model.as_ref().map(|blif_model| {
+        ComplexBlockPrimitiveInfo {
+            blif_model: blif_model.clone(),
+            class: pb_type.class.clone(),
+        }
+    });
+
+    node_id
 }

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -37,6 +37,7 @@ impl_vec_index!(ComplexBlockPinId, ComplexBlockPin);
 impl_vec_index!(ComplexBlockModeId, ComplexBlockMode);
 
 pub struct ComplexBlockMode {
+    pub name: String,
     pub parent_complex_block: ComplexBlockNodeId,
     pub children_complex_blocks: Vec<ComplexBlockNodeId>,
     pub interconnect: Vec<ComplexBlockNet>,
@@ -167,6 +168,7 @@ fn add_pb_type_recursive(
                 .map(|mode| {
                     let mode_id = ComplexBlockModeId(modes.len());
                     modes.push(ComplexBlockMode {
+                        name: mode.name.clone(),
                         parent_complex_block: node_id,
                         children_complex_blocks: Vec::new(),
                         interconnect: Vec::new(),
@@ -182,6 +184,7 @@ fn add_pb_type_recursive(
             // Implicit single default mode for pb_types with direct children but no named modes.
             let mode_id = ComplexBlockModeId(modes.len());
             modes.push(ComplexBlockMode {
+                name: pb_type.name.clone(),
                 parent_complex_block: node_id,
                 children_complex_blocks: Vec::new(),
                 interconnect: Vec::new(),

--- a/fpga_arch_parser/src/complex_block_graph.rs
+++ b/fpga_arch_parser/src/complex_block_graph.rs
@@ -75,10 +75,10 @@ pub struct ComplexBlockNet {
 pub struct ComplexBlockGraph {
     pub root_complex_block_node: ComplexBlockNodeId,
 
-    complex_block_nodes: Vec<ComplexBlockNode>,
-    complex_block_modes: Vec<ComplexBlockMode>,
-    complex_block_ports: Vec<ComplexBlockPort>,
-    complex_block_pins: Vec<ComplexBlockPin>,
+    pub complex_block_nodes: Vec<ComplexBlockNode>,
+    pub complex_block_modes: Vec<ComplexBlockMode>,
+    pub complex_block_ports: Vec<ComplexBlockPort>,
+    pub complex_block_pins: Vec<ComplexBlockPin>,
 }
 
 pub fn build_complex_block_graph(root_pb_type: &PBType) -> Result<ComplexBlockGraph, FPGAArchParseError> {

--- a/fpga_arch_parser/src/lib.rs
+++ b/fpga_arch_parser/src/lib.rs
@@ -27,6 +27,7 @@ mod tile_pin_mapper;
 mod verify_noc;
 
 pub use crate::arch::*;
+use crate::complex_block_graph::build_complex_block_graph;
 pub use crate::parse_error::FPGAArchParseError;
 pub use crate::tile_pin_mapper::*;
 
@@ -292,6 +293,11 @@ fn parse_architecture<R: BufRead>(
         verify_noc(noc_info, &tiles, parser.position())?;
     }
 
+    let mut complex_block_graphs = Vec::with_capacity(complex_block_list.len());
+    for root_pb_type in &complex_block_list {
+        complex_block_graphs.push(build_complex_block_graph(root_pb_type)?);
+    }
+
     Ok(FPGAArch {
         models,
         tiles,
@@ -302,6 +308,7 @@ fn parse_architecture<R: BufRead>(
         custom_switch_blocks,
         direct_list,
         complex_block_list,
+        complex_block_graphs,
         noc,
     })
 }

--- a/fpga_arch_parser/src/lib.rs
+++ b/fpga_arch_parser/src/lib.rs
@@ -29,9 +29,9 @@ mod verify_noc;
 pub use crate::arch::*;
 use crate::complex_block_graph::build_complex_block_graph;
 pub use crate::complex_block_graph::{
-    ComplexBlockGraph, ComplexBlockModeId, ComplexBlockMode, ComplexBlockNet,
-    ComplexBlockNodeId, ComplexBlockNode, ComplexBlockPortId, ComplexBlockPort,
-    ComplexBlockPinId, ComplexBlockPin, ComplexBlockPrimitiveInfo,
+    ComplexBlockGraph, ComplexBlockMode, ComplexBlockModeId, ComplexBlockNet, ComplexBlockNode,
+    ComplexBlockNodeId, ComplexBlockPin, ComplexBlockPinId, ComplexBlockPort, ComplexBlockPortId,
+    ComplexBlockPrimitiveInfo,
 };
 pub use crate::parse_error::FPGAArchParseError;
 pub use crate::tile_pin_mapper::*;

--- a/fpga_arch_parser/src/lib.rs
+++ b/fpga_arch_parser/src/lib.rs
@@ -8,6 +8,7 @@ use xml::name::OwnedName;
 use xml::reader::{EventReader, XmlEvent};
 
 mod arch;
+mod complex_block_graph;
 mod parse_complex_block_list;
 mod parse_custom_switch_blocks;
 mod parse_device;

--- a/fpga_arch_parser/src/lib.rs
+++ b/fpga_arch_parser/src/lib.rs
@@ -28,6 +28,11 @@ mod verify_noc;
 
 pub use crate::arch::*;
 use crate::complex_block_graph::build_complex_block_graph;
+pub use crate::complex_block_graph::{
+    ComplexBlockGraph, ComplexBlockModeId, ComplexBlockMode, ComplexBlockNet,
+    ComplexBlockNodeId, ComplexBlockNode, ComplexBlockPortId, ComplexBlockPort,
+    ComplexBlockPinId, ComplexBlockPin, ComplexBlockPrimitiveInfo,
+};
 pub use crate::parse_error::FPGAArchParseError;
 pub use crate::tile_pin_mapper::*;
 

--- a/fpga_arch_parser/src/parse_complex_block_list.rs
+++ b/fpga_arch_parser/src/parse_complex_block_list.rs
@@ -279,36 +279,25 @@ fn parse_interconnect<R: BufRead>(
         }
     }
 
-    match name.to_string().as_ref() {
-        "direct" => Ok(Interconnect::Direct(DirectInterconnect {
-            name: inter_name,
-            input,
-            output,
-            pack_patterns,
-            delays,
-            metadata,
-        })),
-        "mux" => Ok(Interconnect::Mux(MuxInterconnect {
-            name: inter_name,
-            input,
-            output,
-            pack_patterns,
-            delays,
-            metadata,
-        })),
-        "complete" => Ok(Interconnect::Complete(CompleteInterconnect {
-            name: inter_name,
-            input,
-            output,
-            pack_patterns,
-            delays,
-            metadata,
-        })),
-        _ => Err(FPGAArchParseError::InvalidTag(
+    let interconnect_type = match name.to_string().as_ref() {
+        "direct" => InterconnectType::Direct,
+        "mux" => InterconnectType::Mux,
+        "complete" => InterconnectType::Complete,
+        _ => return Err(FPGAArchParseError::InvalidTag(
             format!("Unknown interconnect tag: {name}"),
             parser.position(),
         )),
-    }
+    };
+
+    Ok(Interconnect {
+        name: inter_name,
+        input,
+        output,
+        interconnect_type,
+        pack_patterns,
+        delays,
+        metadata,
+    })
 }
 
 fn parse_interconnects<R: BufRead>(

--- a/fpga_arch_parser/src/parse_complex_block_list.rs
+++ b/fpga_arch_parser/src/parse_complex_block_list.rs
@@ -486,7 +486,7 @@ fn parse_pb_type<R: BufRead>(
     assert!(name.to_string() == "pb_type");
 
     let mut pb_type_name: Option<String> = None;
-    let mut num_pb: Option<i32> = None;
+    let mut num_pb: Option<usize> = None;
     let mut blif_model: Option<String> = None;
     let mut class: Option<PBTypeClass> = None;
 

--- a/fpga_arch_parser/src/parse_complex_block_list.rs
+++ b/fpga_arch_parser/src/parse_complex_block_list.rs
@@ -283,10 +283,12 @@ fn parse_interconnect<R: BufRead>(
         "direct" => InterconnectType::Direct,
         "mux" => InterconnectType::Mux,
         "complete" => InterconnectType::Complete,
-        _ => return Err(FPGAArchParseError::InvalidTag(
-            format!("Unknown interconnect tag: {name}"),
-            parser.position(),
-        )),
+        _ => {
+            return Err(FPGAArchParseError::InvalidTag(
+                format!("Unknown interconnect tag: {name}"),
+                parser.position(),
+            ));
+        }
     };
 
     Ok(Interconnect {

--- a/fpga_arch_parser/src/parse_port.rs
+++ b/fpga_arch_parser/src/parse_port.rs
@@ -70,7 +70,7 @@ pub fn parse_port<R: BufRead>(
     parser: &mut EventReader<R>,
 ) -> Result<Port, FPGAArchParseError> {
     let mut port_name: Option<String> = None;
-    let mut num_pins: Option<i32> = None;
+    let mut num_pins: Option<usize> = None;
     let mut equivalent: Option<PinEquivalence> = None;
     let mut is_non_clock_global: Option<bool> = None;
     let mut port_class: Option<PortClass> = None;

--- a/fpga_arch_parser/src/tile_pin_mapper.rs
+++ b/fpga_arch_parser/src/tile_pin_mapper.rs
@@ -119,7 +119,6 @@ pub fn build_tile_pin_mapper(
                     Port::Output(output_port) => (&output_port.name, output_port.num_pins),
                     Port::Clock(clock_port) => (&clock_port.name, clock_port.num_pins),
                 };
-                let num_pins = num_pins as usize;
                 let mut pin_indices = Vec::new();
                 for pin_index in num_pins_in_tile..num_pins_in_tile + num_pins {
                     pin_indices.push(pin_index);
@@ -347,7 +346,7 @@ fn get_pins_in_pin_loc(
         };
         let port_bus = match port_bus_slice {
             Some(bus_slice) => parse_bus(bus_slice)?,
-            None => 0..=(num_port_pins - 1),
+            None => 0..=(num_port_pins as i32 - 1),
         };
 
         // Get the pins.
@@ -360,7 +359,7 @@ fn get_pins_in_pin_loc(
             let sub_tile_pin_index_lookup =
                 &pin_index_lookup[sub_tile_name][sub_tile_cap_index as usize][port_name];
             for bit in port_bus.clone() {
-                if bit < 0 || bit >= num_port_pins {
+                if bit < 0 || bit >= num_port_pins as i32 {
                     return Err(FPGAArchParseError::PinParsingError(
                         "Invalid port bit position.".to_string(),
                     ));

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -1,9 +1,11 @@
 use std::path::{PathBuf, absolute};
 
 use fpga_arch_parser::{
-    ChanWDist, CustomSwitchBlockLocation, CustomSwitchBlockType, FPGAArchParseError, GridLocation,
-    Layout, Port, SBType, SegmentType, SubTileIOFC, SubTilePinLocations, SwitchBlockLocationType,
-    SwitchBlockLocationsPattern, SwitchBufSize, SwitchType, TileSitePinMapping,
+    ChanWDist, ComplexBlockGraph, ComplexBlockModeId, ComplexBlockNode, ComplexBlockNodeId,
+    ComplexBlockPort, ComplexBlockPortId, CustomSwitchBlockLocation, CustomSwitchBlockType,
+    FPGAArchParseError, GridLocation, Layout, PBTypeClass, Port, SBType, SegmentType,
+    SubTileIOFC, SubTilePinLocations, SwitchBlockLocationType, SwitchBlockLocationsPattern,
+    SwitchBufSize, SwitchType, TileSitePinMapping,
 };
 
 #[test]
@@ -677,6 +679,180 @@ fn mesh_noc_topology() -> Result<(), FPGAArchParseError> {
     assert_eq!(routers[3].position_y, 5.0);
     assert_eq!(routers[3].layer, 0);
     assert_eq!(routers[3].connections, vec![2, 1]);
+
+    Ok(())
+}
+
+#[test]
+fn test_k4_n4_90nm_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
+    let input_xml_relative = PathBuf::from("tests/k4_N4_90nm.xml");
+    let input_xml = absolute(&input_xml_relative).expect("Failed to get absolute path");
+    let res = fpga_arch_parser::parse(&input_xml)?;
+
+    // One graph per complex block (io and clb).
+    assert_eq!(res.complex_block_graphs.len(), 2);
+    let g = &res.complex_block_graphs[1];
+
+    // --- Root: clb ---
+    let root_id = g.root_complex_block_node;
+    let root = &g.complex_block_nodes[root_id];
+    assert_eq!(root.name, "clb");
+    assert!(root.parent_mode.is_none());
+    assert!(root.primitive_info.is_none());
+
+    // Ports: I[10], O[4], clk[1].
+    assert_eq!(root.input_ports.len(), 1);
+    assert_eq!(root.output_ports.len(), 1);
+    assert_eq!(root.clock_ports.len(), 1);
+    let port_i = &g.complex_block_ports[root.input_ports[0]];
+    assert_eq!(port_i.name, "I");
+    assert_eq!(port_i.pins.len(), 10);
+    let port_o = &g.complex_block_ports[root.output_ports[0]];
+    assert_eq!(port_o.name, "O");
+    assert_eq!(port_o.pins.len(), 4);
+    let port_clk = &g.complex_block_ports[root.clock_ports[0]];
+    assert_eq!(port_clk.name, "clk");
+    assert_eq!(port_clk.pins.len(), 1);
+
+    // clb has one implicit mode (no named modes, but has direct pb_type children).
+    assert_eq!(root.modes.len(), 1);
+    let clb_mode = &g.complex_block_modes[root.modes[0]];
+
+    // Mode children: 4 fle instances + 3 interconnects (crossbar, clks, clbouts1).
+    assert_eq!(clb_mode.children_complex_blocks.len(), 7);
+
+    // --- fle instances [0..3] ---
+    for i in 0..4 {
+        let fle = &g.complex_block_nodes[clb_mode.children_complex_blocks[i]];
+        assert_eq!(fle.name, "fle");
+        assert_eq!(fle.input_ports.len(), 1);
+        assert_eq!(fle.output_ports.len(), 1);
+        assert_eq!(fle.clock_ports.len(), 1);
+        assert_eq!(g.complex_block_ports[fle.input_ports[0]].pins.len(), 4);
+        assert_eq!(g.complex_block_ports[fle.output_ports[0]].pins.len(), 1);
+        assert_eq!(g.complex_block_ports[fle.clock_ports[0]].pins.len(), 1);
+
+        // fle has one explicit mode: n1_lut4.
+        assert_eq!(fle.modes.len(), 1);
+        let fle_mode = &g.complex_block_modes[fle.modes[0]];
+
+        // Mode children: 1 ble4 + 3 interconnects (direct1, direct2, direct3).
+        assert_eq!(fle_mode.children_complex_blocks.len(), 4);
+
+        // --- ble4 ---
+        let ble4 = &g.complex_block_nodes[fle_mode.children_complex_blocks[0]];
+        assert_eq!(ble4.name, "ble4");
+        assert_eq!(ble4.input_ports.len(), 1);
+        assert_eq!(ble4.output_ports.len(), 1);
+        assert_eq!(ble4.clock_ports.len(), 1);
+        assert_eq!(g.complex_block_ports[ble4.input_ports[0]].pins.len(), 4);
+        assert_eq!(g.complex_block_ports[ble4.output_ports[0]].pins.len(), 1);
+        assert_eq!(g.complex_block_ports[ble4.clock_ports[0]].pins.len(), 1);
+
+        // ble4 has one implicit mode.
+        assert_eq!(ble4.modes.len(), 1);
+        let ble4_mode = &g.complex_block_modes[ble4.modes[0]];
+
+        // Mode children: lut4, ff, + 4 interconnects (direct1..3, mux1).
+        assert_eq!(ble4_mode.children_complex_blocks.len(), 6);
+
+        // lut4: leaf primitive, class Lut, ports in[4] out[1].
+        let lut4 = &g.complex_block_nodes[ble4_mode.children_complex_blocks[0]];
+        assert_eq!(lut4.name, "lut4");
+        assert_eq!(lut4.input_ports.len(), 1);
+        assert_eq!(lut4.output_ports.len(), 1);
+        assert_eq!(lut4.clock_ports.len(), 0);
+        assert_eq!(g.complex_block_ports[lut4.input_ports[0]].pins.len(), 4);
+        assert_eq!(g.complex_block_ports[lut4.output_ports[0]].pins.len(), 1);
+        let lut4_info = lut4.primitive_info.as_ref().expect("lut4 must have primitive_info");
+        assert_eq!(lut4_info.blif_model, ".names");
+        assert!(matches!(lut4_info.class, PBTypeClass::Lut));
+
+        // ff: leaf primitive, class FlipFlop, ports D[1] Q[1] clk[1].
+        let ff = &g.complex_block_nodes[ble4_mode.children_complex_blocks[1]];
+        assert_eq!(ff.name, "ff");
+        assert_eq!(ff.input_ports.len(), 1);
+        assert_eq!(ff.output_ports.len(), 1);
+        assert_eq!(ff.clock_ports.len(), 1);
+        assert_eq!(g.complex_block_ports[ff.input_ports[0]].pins.len(), 1);
+        assert_eq!(g.complex_block_ports[ff.output_ports[0]].pins.len(), 1);
+        assert_eq!(g.complex_block_ports[ff.clock_ports[0]].pins.len(), 1);
+        let ff_info = ff.primitive_info.as_ref().expect("ff must have primitive_info");
+        assert_eq!(ff_info.blif_model, ".latch");
+        assert!(matches!(ff_info.class, PBTypeClass::FlipFlop));
+
+        // ble4 interconnects: direct1, direct2, direct3 (Direct), mux1 (Mux).
+        let ble4_direct1 = &g.complex_block_nodes[ble4_mode.children_complex_blocks[2]];
+        assert_eq!(ble4_direct1.name, "direct1");
+        assert!(matches!(
+            ble4_direct1.primitive_info.as_ref().unwrap().class,
+            PBTypeClass::InterconnectDirect
+        ));
+        let ble4_mux1 = &g.complex_block_nodes[ble4_mode.children_complex_blocks[5]];
+        assert_eq!(ble4_mux1.name, "mux1");
+        assert!(matches!(
+            ble4_mux1.primitive_info.as_ref().unwrap().class,
+            PBTypeClass::InterconnectMux
+        ));
+        // mux1 has 2 input groups (ff.Q and lut4.out) → 2 input ports.
+        assert_eq!(ble4_mux1.input_ports.len(), 2);
+        assert_eq!(ble4_mux1.output_ports.len(), 1);
+
+        // fle interconnects: direct1, direct2, direct3 (all Direct).
+        for j in 1..4 {
+            let fle_inter = &g.complex_block_nodes[fle_mode.children_complex_blocks[j]];
+            assert!(matches!(
+                fle_inter.primitive_info.as_ref().unwrap().class,
+                PBTypeClass::InterconnectDirect
+            ));
+        }
+    }
+
+    // --- clb-level interconnects ---
+    // crossbar: complete, 2 input groups (clb.I and fle[3:0].out), output fle[3:0].in.
+    let crossbar = &g.complex_block_nodes[clb_mode.children_complex_blocks[4]];
+    assert_eq!(crossbar.name, "crossbar");
+    assert!(matches!(
+        crossbar.primitive_info.as_ref().unwrap().class,
+        PBTypeClass::InterconnectComplete
+    ));
+    assert_eq!(crossbar.input_ports.len(), 2);
+    // input_0 mirrors clb.I (10 pins), input_1 mirrors fle[3:0].out (4 pins).
+    assert_eq!(g.complex_block_ports[crossbar.input_ports[0]].pins.len(), 10);
+    assert_eq!(g.complex_block_ports[crossbar.input_ports[1]].pins.len(), 4);
+    // output mirrors fle[3:0].in (4 fle × 4 pins = 16 pins).
+    assert_eq!(crossbar.output_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[crossbar.output_ports[0]].pins.len(), 16);
+
+    // clks: complete, 1 input group (clb.clk), output fle[3:0].clk.
+    let clks = &g.complex_block_nodes[clb_mode.children_complex_blocks[5]];
+    assert_eq!(clks.name, "clks");
+    assert!(matches!(
+        clks.primitive_info.as_ref().unwrap().class,
+        PBTypeClass::InterconnectComplete
+    ));
+    assert_eq!(clks.input_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[clks.input_ports[0]].pins.len(), 1);
+    assert_eq!(clks.output_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[clks.output_ports[0]].pins.len(), 4);
+
+    // clbouts1: direct, input fle[3:0].out (4 pins), output clb.O (4 pins).
+    let clbouts1 = &g.complex_block_nodes[clb_mode.children_complex_blocks[6]];
+    assert_eq!(clbouts1.name, "clbouts1");
+    assert!(matches!(
+        clbouts1.primitive_info.as_ref().unwrap().class,
+        PBTypeClass::InterconnectDirect
+    ));
+    assert_eq!(clbouts1.input_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[clbouts1.input_ports[0]].pins.len(), 4);
+    assert_eq!(clbouts1.output_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[clbouts1.output_ports[0]].pins.len(), 4);
+
+    // --- Net counts ---
+    // crossbar: 10 + 4 input-side nets + 16 output-side nets = 30.
+    // clks: 1 input-side + 4 output-side = 5.
+    // clbouts1: 4 input-side + 4 output-side = 8.
+    assert_eq!(clb_mode.interconnect.len(), 43);
 
     Ok(())
 }

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -754,13 +754,19 @@ fn test_k6_n10_sparse_crossbar_clb_complex_block_graph() -> Result<(), FPGAArchP
         let lut6 = &g.complex_block_nodes[ble6_mode.children_complex_blocks[0]];
         assert_eq!(lut6.name, "lut6");
         assert_eq!(g.complex_block_ports[lut6.input_ports[0]].pins.len(), 6);
-        let lut6_info = lut6.primitive_info.as_ref().expect("lut6 must have primitive_info");
+        let lut6_info = lut6
+            .primitive_info
+            .as_ref()
+            .expect("lut6 must have primitive_info");
         assert_eq!(lut6_info.blif_model, ".names");
         assert!(matches!(lut6_info.class, PBTypeClass::Lut));
 
         let ff = &g.complex_block_nodes[ble6_mode.children_complex_blocks[1]];
         assert_eq!(ff.name, "ff");
-        let ff_info = ff.primitive_info.as_ref().expect("ff must have primitive_info");
+        let ff_info = ff
+            .primitive_info
+            .as_ref()
+            .expect("ff must have primitive_info");
         assert_eq!(ff_info.blif_model, ".latch");
         assert!(matches!(ff_info.class, PBTypeClass::FlipFlop));
     }
@@ -774,9 +780,15 @@ fn test_k6_n10_sparse_crossbar_clb_complex_block_graph() -> Result<(), FPGAArchP
         PBTypeClass::InterconnectComplete
     ));
     assert_eq!(crossbar.input_ports.len(), 1);
-    assert_eq!(g.complex_block_ports[crossbar.input_ports[0]].pins.len(), 10);
+    assert_eq!(
+        g.complex_block_ports[crossbar.input_ports[0]].pins.len(),
+        10
+    );
     assert_eq!(crossbar.output_ports.len(), 1);
-    assert_eq!(g.complex_block_ports[crossbar.output_ports[0]].pins.len(), 60);
+    assert_eq!(
+        g.complex_block_ports[crossbar.output_ports[0]].pins.len(),
+        60
+    );
 
     // pin0_mux..pin4_mux: each driven by a 7-pin CLB input, fanning out to bit [x:x] of fle[9:0].in (10 pins).
     let pin_mux_names = ["pin0_mux", "pin1_mux", "pin2_mux", "pin3_mux", "pin4_mux"];
@@ -797,7 +809,10 @@ fn test_k6_n10_sparse_crossbar_clb_complex_block_graph() -> Result<(), FPGAArchP
     let pin5_mux = &g.complex_block_nodes[clb_mode.children_complex_blocks[16]];
     assert_eq!(pin5_mux.name, "pin5_mux");
     assert_eq!(g.complex_block_ports[pin5_mux.input_ports[0]].pins.len(), 5);
-    assert_eq!(g.complex_block_ports[pin5_mux.output_ports[0]].pins.len(), 10);
+    assert_eq!(
+        g.complex_block_ports[pin5_mux.output_ports[0]].pins.len(),
+        10
+    );
 
     // clks: complete, 1 input pin (clb.clk), 10 output pins (fle[9:0].clk).
     let clks = &g.complex_block_nodes[clb_mode.children_complex_blocks[17]];
@@ -812,8 +827,14 @@ fn test_k6_n10_sparse_crossbar_clb_complex_block_graph() -> Result<(), FPGAArchP
         clbouts1.primitive_info.as_ref().unwrap().class,
         PBTypeClass::InterconnectDirect
     ));
-    assert_eq!(g.complex_block_ports[clbouts1.input_ports[0]].pins.len(), 10);
-    assert_eq!(g.complex_block_ports[clbouts1.output_ports[0]].pins.len(), 10);
+    assert_eq!(
+        g.complex_block_ports[clbouts1.input_ports[0]].pins.len(),
+        10
+    );
+    assert_eq!(
+        g.complex_block_ports[clbouts1.output_ports[0]].pins.len(),
+        10
+    );
 
     // --- Net count ---
     // crossbar:   10 input-side + 60 output-side = 70

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -1,11 +1,10 @@
 use std::path::{PathBuf, absolute};
 
 use fpga_arch_parser::{
-    ChanWDist, ComplexBlockGraph, ComplexBlockModeId, ComplexBlockNode, ComplexBlockNodeId,
-    ComplexBlockPort, ComplexBlockPortId, CustomSwitchBlockLocation, CustomSwitchBlockType,
-    FPGAArchParseError, GridLocation, Layout, PBTypeClass, Port, SBType, SegmentType,
-    SubTileIOFC, SubTilePinLocations, SwitchBlockLocationType, SwitchBlockLocationsPattern,
-    SwitchBufSize, SwitchType, TileSitePinMapping,
+    ChanWDist, CustomSwitchBlockLocation, CustomSwitchBlockType, FPGAArchParseError, GridLocation,
+    Layout, PBTypeClass, Port, SBType, SegmentType, SubTileIOFC, SubTilePinLocations,
+    SwitchBlockLocationType, SwitchBlockLocationsPattern, SwitchBufSize, SwitchType,
+    TileSitePinMapping,
 };
 
 #[test]
@@ -764,7 +763,10 @@ fn test_k4_n4_90nm_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
         assert_eq!(lut4.clock_ports.len(), 0);
         assert_eq!(g.complex_block_ports[lut4.input_ports[0]].pins.len(), 4);
         assert_eq!(g.complex_block_ports[lut4.output_ports[0]].pins.len(), 1);
-        let lut4_info = lut4.primitive_info.as_ref().expect("lut4 must have primitive_info");
+        let lut4_info = lut4
+            .primitive_info
+            .as_ref()
+            .expect("lut4 must have primitive_info");
         assert_eq!(lut4_info.blif_model, ".names");
         assert!(matches!(lut4_info.class, PBTypeClass::Lut));
 
@@ -777,7 +779,10 @@ fn test_k4_n4_90nm_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
         assert_eq!(g.complex_block_ports[ff.input_ports[0]].pins.len(), 1);
         assert_eq!(g.complex_block_ports[ff.output_ports[0]].pins.len(), 1);
         assert_eq!(g.complex_block_ports[ff.clock_ports[0]].pins.len(), 1);
-        let ff_info = ff.primitive_info.as_ref().expect("ff must have primitive_info");
+        let ff_info = ff
+            .primitive_info
+            .as_ref()
+            .expect("ff must have primitive_info");
         assert_eq!(ff_info.blif_model, ".latch");
         assert!(matches!(ff_info.class, PBTypeClass::FlipFlop));
 
@@ -818,11 +823,17 @@ fn test_k4_n4_90nm_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
     ));
     assert_eq!(crossbar.input_ports.len(), 2);
     // input_0 mirrors clb.I (10 pins), input_1 mirrors fle[3:0].out (4 pins).
-    assert_eq!(g.complex_block_ports[crossbar.input_ports[0]].pins.len(), 10);
+    assert_eq!(
+        g.complex_block_ports[crossbar.input_ports[0]].pins.len(),
+        10
+    );
     assert_eq!(g.complex_block_ports[crossbar.input_ports[1]].pins.len(), 4);
     // output mirrors fle[3:0].in (4 fle × 4 pins = 16 pins).
     assert_eq!(crossbar.output_ports.len(), 1);
-    assert_eq!(g.complex_block_ports[crossbar.output_ports[0]].pins.len(), 16);
+    assert_eq!(
+        g.complex_block_ports[crossbar.output_ports[0]].pins.len(),
+        16
+    );
 
     // clks: complete, 1 input group (clb.clk), output fle[3:0].clk.
     let clks = &g.complex_block_nodes[clb_mode.children_complex_blocks[5]];
@@ -846,7 +857,10 @@ fn test_k4_n4_90nm_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
     assert_eq!(clbouts1.input_ports.len(), 1);
     assert_eq!(g.complex_block_ports[clbouts1.input_ports[0]].pins.len(), 4);
     assert_eq!(clbouts1.output_ports.len(), 1);
-    assert_eq!(g.complex_block_ports[clbouts1.output_ports[0]].pins.len(), 4);
+    assert_eq!(
+        g.complex_block_ports[clbouts1.output_ports[0]].pins.len(),
+        4
+    );
 
     // --- Net counts ---
     // crossbar: 10 + 4 input-side nets + 16 output-side nets = 30.

--- a/fpga_arch_parser/tests/integration_test.rs
+++ b/fpga_arch_parser/tests/integration_test.rs
@@ -683,6 +683,151 @@ fn mesh_noc_topology() -> Result<(), FPGAArchParseError> {
 }
 
 #[test]
+fn test_k6_n10_sparse_crossbar_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
+    let input_xml_relative = PathBuf::from("tests/k6_N10_sparse_crossbar_40nm.xml");
+    let input_xml = absolute(&input_xml_relative).expect("Failed to get absolute path");
+    let res = fpga_arch_parser::parse(&input_xml)?;
+
+    assert_eq!(res.complex_block_graphs.len(), 2);
+    let g = &res.complex_block_graphs[1];
+
+    // --- Root: clb ---
+    let root_id = g.root_complex_block_node;
+    let root = &g.complex_block_nodes[root_id];
+    assert_eq!(root.name, "clb");
+    assert!(root.parent_mode.is_none());
+    assert!(root.primitive_info.is_none());
+
+    // Ports: I0[7], I1[7], I2[7], I3[7], I4[7], I5[5], O[10], clk[1].
+    assert_eq!(root.input_ports.len(), 6);
+    assert_eq!(root.output_ports.len(), 1);
+    assert_eq!(root.clock_ports.len(), 1);
+    let input_pin_counts = [7usize, 7, 7, 7, 7, 5];
+    let input_names = ["I0", "I1", "I2", "I3", "I4", "I5"];
+    for (idx, (expected_name, expected_pins)) in
+        input_names.iter().zip(input_pin_counts.iter()).enumerate()
+    {
+        let port = &g.complex_block_ports[root.input_ports[idx]];
+        assert_eq!(port.name, *expected_name);
+        assert_eq!(port.pins.len(), *expected_pins);
+    }
+    let port_o = &g.complex_block_ports[root.output_ports[0]];
+    assert_eq!(port_o.name, "O");
+    assert_eq!(port_o.pins.len(), 10);
+    let port_clk = &g.complex_block_ports[root.clock_ports[0]];
+    assert_eq!(port_clk.name, "clk");
+    assert_eq!(port_clk.pins.len(), 1);
+
+    // clb has one implicit mode.
+    assert_eq!(root.modes.len(), 1);
+    let clb_mode = &g.complex_block_modes[root.modes[0]];
+
+    // Mode children: 10 fle instances + 9 interconnects.
+    assert_eq!(clb_mode.children_complex_blocks.len(), 19);
+
+    // --- fle instances [0..9] ---
+    for i in 0..10 {
+        let fle = &g.complex_block_nodes[clb_mode.children_complex_blocks[i]];
+        assert_eq!(fle.name, "fle");
+        assert_eq!(fle.input_ports.len(), 1);
+        assert_eq!(fle.output_ports.len(), 1);
+        assert_eq!(fle.clock_ports.len(), 1);
+        assert_eq!(g.complex_block_ports[fle.input_ports[0]].pins.len(), 6);
+        assert_eq!(g.complex_block_ports[fle.output_ports[0]].pins.len(), 1);
+        assert_eq!(g.complex_block_ports[fle.clock_ports[0]].pins.len(), 1);
+
+        // fle has one explicit mode: n1_lut6.
+        assert_eq!(fle.modes.len(), 1);
+        let fle_mode = &g.complex_block_modes[fle.modes[0]];
+
+        // 1 ble6 + 3 direct interconnects.
+        assert_eq!(fle_mode.children_complex_blocks.len(), 4);
+
+        let ble6 = &g.complex_block_nodes[fle_mode.children_complex_blocks[0]];
+        assert_eq!(ble6.name, "ble6");
+        assert_eq!(ble6.modes.len(), 1);
+        let ble6_mode = &g.complex_block_modes[ble6.modes[0]];
+
+        // lut6 + ff + 4 interconnects (direct1..3, mux1).
+        assert_eq!(ble6_mode.children_complex_blocks.len(), 6);
+
+        let lut6 = &g.complex_block_nodes[ble6_mode.children_complex_blocks[0]];
+        assert_eq!(lut6.name, "lut6");
+        assert_eq!(g.complex_block_ports[lut6.input_ports[0]].pins.len(), 6);
+        let lut6_info = lut6.primitive_info.as_ref().expect("lut6 must have primitive_info");
+        assert_eq!(lut6_info.blif_model, ".names");
+        assert!(matches!(lut6_info.class, PBTypeClass::Lut));
+
+        let ff = &g.complex_block_nodes[ble6_mode.children_complex_blocks[1]];
+        assert_eq!(ff.name, "ff");
+        let ff_info = ff.primitive_info.as_ref().expect("ff must have primitive_info");
+        assert_eq!(ff_info.blif_model, ".latch");
+        assert!(matches!(ff_info.class, PBTypeClass::FlipFlop));
+    }
+
+    // --- clb-level interconnects (children [10..18]) ---
+    // crossbar: complete, 1 input group = fle[9:0].out (10 pins), output = fle[9:0].in (60 pins).
+    let crossbar = &g.complex_block_nodes[clb_mode.children_complex_blocks[10]];
+    assert_eq!(crossbar.name, "crossbar");
+    assert!(matches!(
+        crossbar.primitive_info.as_ref().unwrap().class,
+        PBTypeClass::InterconnectComplete
+    ));
+    assert_eq!(crossbar.input_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[crossbar.input_ports[0]].pins.len(), 10);
+    assert_eq!(crossbar.output_ports.len(), 1);
+    assert_eq!(g.complex_block_ports[crossbar.output_ports[0]].pins.len(), 60);
+
+    // pin0_mux..pin4_mux: each driven by a 7-pin CLB input, fanning out to bit [x:x] of fle[9:0].in (10 pins).
+    let pin_mux_names = ["pin0_mux", "pin1_mux", "pin2_mux", "pin3_mux", "pin4_mux"];
+    for (offset, name) in pin_mux_names.iter().enumerate() {
+        let mux = &g.complex_block_nodes[clb_mode.children_complex_blocks[11 + offset]];
+        assert_eq!(mux.name, *name);
+        assert!(matches!(
+            mux.primitive_info.as_ref().unwrap().class,
+            PBTypeClass::InterconnectComplete
+        ));
+        assert_eq!(mux.input_ports.len(), 1);
+        assert_eq!(g.complex_block_ports[mux.input_ports[0]].pins.len(), 7);
+        assert_eq!(mux.output_ports.len(), 1);
+        assert_eq!(g.complex_block_ports[mux.output_ports[0]].pins.len(), 10);
+    }
+
+    // pin5_mux: driven by I5 which has 5 pins (not 7), same 10-pin output.
+    let pin5_mux = &g.complex_block_nodes[clb_mode.children_complex_blocks[16]];
+    assert_eq!(pin5_mux.name, "pin5_mux");
+    assert_eq!(g.complex_block_ports[pin5_mux.input_ports[0]].pins.len(), 5);
+    assert_eq!(g.complex_block_ports[pin5_mux.output_ports[0]].pins.len(), 10);
+
+    // clks: complete, 1 input pin (clb.clk), 10 output pins (fle[9:0].clk).
+    let clks = &g.complex_block_nodes[clb_mode.children_complex_blocks[17]];
+    assert_eq!(clks.name, "clks");
+    assert_eq!(g.complex_block_ports[clks.input_ports[0]].pins.len(), 1);
+    assert_eq!(g.complex_block_ports[clks.output_ports[0]].pins.len(), 10);
+
+    // clbouts1: direct, 10 input pins (fle[9:0].out), 10 output pins (clb.O).
+    let clbouts1 = &g.complex_block_nodes[clb_mode.children_complex_blocks[18]];
+    assert_eq!(clbouts1.name, "clbouts1");
+    assert!(matches!(
+        clbouts1.primitive_info.as_ref().unwrap().class,
+        PBTypeClass::InterconnectDirect
+    ));
+    assert_eq!(g.complex_block_ports[clbouts1.input_ports[0]].pins.len(), 10);
+    assert_eq!(g.complex_block_ports[clbouts1.output_ports[0]].pins.len(), 10);
+
+    // --- Net count ---
+    // crossbar:   10 input-side + 60 output-side = 70
+    // pin0..4_mux: 5 × (7 + 10)                 = 85
+    // pin5_mux:    5 + 10                        = 15
+    // clks:        1 + 10                        = 11
+    // clbouts1:   10 + 10                        = 20
+    // Total: 201
+    assert_eq!(clb_mode.interconnect.len(), 201);
+
+    Ok(())
+}
+
+#[test]
 fn test_k4_n4_90nm_clb_complex_block_graph() -> Result<(), FPGAArchParseError> {
     let input_xml_relative = PathBuf::from("tests/k4_N4_90nm.xml");
     let input_xml = absolute(&input_xml_relative).expect("Failed to get absolute path");

--- a/fpga_arch_viewer/src/intra_block_drawing.rs
+++ b/fpga_arch_viewer/src/intra_block_drawing.rs
@@ -191,7 +191,7 @@ fn draw_pins_on_side(
 
 struct PinInfo<'a> {
     name: &'a str,
-    index: i32,
+    index: usize,
 }
 
 //-----------------------------------------------------------

--- a/fpga_arch_viewer/src/intra_hierarchy_tree.rs
+++ b/fpga_arch_viewer/src/intra_hierarchy_tree.rs
@@ -71,7 +71,10 @@ fn render_pb_type_tree_node(ui: &mut egui::Ui, pb_type: &PBType) {
                 PBTypeClass::Memory => {
                     ui.label(egui::RichText::new("[MEM]").color(egui::Color32::GREEN));
                 }
-                PBTypeClass::None => {}
+                PBTypeClass::None
+                | PBTypeClass::InterconnectDirect
+                | PBTypeClass::InterconnectMux
+                | PBTypeClass::InterconnectComplete => {}
             }
         });
 

--- a/fpga_arch_viewer/src/intra_hierarchy_tree.rs
+++ b/fpga_arch_viewer/src/intra_hierarchy_tree.rs
@@ -40,8 +40,12 @@ fn render_interconnects(ui: &mut egui::Ui, interconnects: &[fpga_arch_parser::In
             fpga_arch_parser::InterconnectType::Mux => "Mux",
             fpga_arch_parser::InterconnectType::Complete => "Complete",
         };
-        let (name, input, output, pack_patterns) =
-            (&inter.name, &inter.input, &inter.output, &inter.pack_patterns);
+        let (name, input, output, pack_patterns) = (
+            &inter.name,
+            &inter.input,
+            &inter.output,
+            &inter.pack_patterns,
+        );
         ui.horizontal(|ui| {
             ui.label(format!("{}: {} ({} -> {})", kind, name, input, output));
             if !pack_patterns.is_empty() {

--- a/fpga_arch_viewer/src/intra_hierarchy_tree.rs
+++ b/fpga_arch_viewer/src/intra_hierarchy_tree.rs
@@ -35,17 +35,13 @@ pub fn render_hierarchy_tree(ui: &mut egui::Ui, arch: &FPGAArch, tile: &Tile) {
 
 fn render_interconnects(ui: &mut egui::Ui, interconnects: &[fpga_arch_parser::Interconnect]) {
     for inter in interconnects {
-        let (kind, name, input, output, pack_patterns) = match inter {
-            fpga_arch_parser::Interconnect::Direct(d) => {
-                ("Direct", &d.name, &d.input, &d.output, &d.pack_patterns)
-            }
-            fpga_arch_parser::Interconnect::Mux(m) => {
-                ("Mux", &m.name, &m.input, &m.output, &m.pack_patterns)
-            }
-            fpga_arch_parser::Interconnect::Complete(c) => {
-                ("Complete", &c.name, &c.input, &c.output, &c.pack_patterns)
-            }
+        let kind = match inter.interconnect_type {
+            fpga_arch_parser::InterconnectType::Direct => "Direct",
+            fpga_arch_parser::InterconnectType::Mux => "Mux",
+            fpga_arch_parser::InterconnectType::Complete => "Complete",
         };
+        let (name, input, output, pack_patterns) =
+            (&inter.name, &inter.input, &inter.output, &inter.pack_patterns);
         ui.horizontal(|ui| {
             ui.label(format!("{}: {} ({} -> {})", kind, name, input, output));
             if !pack_patterns.is_empty() {

--- a/fpga_arch_viewer/src/intra_tile.rs
+++ b/fpga_arch_viewer/src/intra_tile.rs
@@ -281,7 +281,7 @@ enum PortType {
 }
 
 /// Counts pins of a specific type in a PBType.
-fn count_pins(pb_type: &PBType, port_type: PortType) -> i32 {
+fn count_pins(pb_type: &PBType, port_type: PortType) -> usize {
     pb_type
         .ports
         .iter()

--- a/fpga_arch_viewer/src/intra_tile.rs
+++ b/fpga_arch_viewer/src/intra_tile.rs
@@ -512,7 +512,7 @@ fn measure_pb_type(
     let has_complete_interconnect = pb_type
         .interconnects
         .iter()
-        .any(|i| matches!(i, fpga_arch_parser::Interconnect::Complete(_)));
+        .any(|i| matches!(i.interconnect_type, fpga_arch_parser::InterconnectType::Complete));
 
     let is_clock_complete = pb_type
         .interconnects
@@ -521,7 +521,7 @@ fn measure_pb_type(
 
     let mux_count = get_interconnects_for_mode(pb_type, mode_index)
         .iter()
-        .filter(|i| matches!(i, fpga_arch_parser::Interconnect::Mux(_)))
+        .filter(|i| matches!(i.interconnect_type, fpga_arch_parser::InterconnectType::Mux))
         .count();
     let mux_gutter = if mux_count >= MUX_GUTTER_MIN_MUXES {
         MUX_GUTTER * zoom
@@ -723,10 +723,10 @@ fn is_clock_complete_interconnect(
     current_pb: &PBType,
     children: &[PBType],
 ) -> bool {
-    if let fpga_arch_parser::Interconnect::Complete(c) = interconnect {
+    if matches!(interconnect.interconnect_type, fpga_arch_parser::InterconnectType::Complete) {
         // Expand port lists to get individual port references
-        let raw_inputs = expand_port_list(&c.input);
-        let raw_outputs = expand_port_list(&c.output);
+        let raw_inputs = expand_port_list(&interconnect.input);
+        let raw_outputs = expand_port_list(&interconnect.output);
 
         // Check if all input ports are clock ports
         let all_inputs_clock = raw_inputs
@@ -915,7 +915,7 @@ fn draw_pb_type(
     let has_complete_interconnect = pb_type
         .interconnects
         .iter()
-        .any(|i| matches!(i, fpga_arch_parser::Interconnect::Complete(_)));
+        .any(|i| matches!(i.interconnect_type, fpga_arch_parser::InterconnectType::Complete));
     let _is_clock_complete = pb_type
         .interconnects
         .iter()
@@ -1074,7 +1074,7 @@ fn draw_pb_type(
 
         let mux_count = get_interconnects_for_mode(pb_type, mode_index)
             .iter()
-            .filter(|i| matches!(i, fpga_arch_parser::Interconnect::Mux(_)))
+            .filter(|i| matches!(i.interconnect_type, fpga_arch_parser::InterconnectType::Mux))
             .count();
         let mux_gutter = if mux_count >= MUX_GUTTER_MIN_MUXES {
             MUX_GUTTER * zoom
@@ -1131,10 +1131,10 @@ fn draw_pb_type(
         let interconnects = get_interconnects_for_mode(pb_type, mode_index);
 
         for inter in interconnects {
-            match inter {
-                fpga_arch_parser::Interconnect::Direct(d) => {
-                    let raw_sources = expand_port_list(&d.input);
-                    let raw_sinks = expand_port_list(&d.output);
+            match inter.interconnect_type {
+                fpga_arch_parser::InterconnectType::Direct => {
+                    let raw_sources = expand_port_list(&inter.input);
+                    let raw_sinks = expand_port_list(&inter.output);
                     let mut sources =
                         resolve_bus_list(&raw_sources, &pb_type.name, &my_ports, &children_ports);
                     let mut sinks =
@@ -1203,9 +1203,9 @@ fn draw_pb_type(
                         }
                     }
                 }
-                fpga_arch_parser::Interconnect::Mux(m) => {
-                    let raw_sources = expand_port_list(&m.input);
-                    let raw_sinks = expand_port_list(&m.output);
+                fpga_arch_parser::InterconnectType::Mux => {
+                    let raw_sources = expand_port_list(&inter.input);
+                    let raw_sinks = expand_port_list(&inter.output);
                     let sources =
                         resolve_bus_list(&raw_sources, &pb_type.name, &my_ports, &children_ports);
                     let sinks =
@@ -1226,9 +1226,9 @@ fn draw_pb_type(
                         dark_mode,
                     );
                 }
-                fpga_arch_parser::Interconnect::Complete(c) => {
-                    let raw_sources = expand_port_list(&c.input);
-                    let raw_sinks = expand_port_list(&c.output);
+                fpga_arch_parser::InterconnectType::Complete => {
+                    let raw_sources = expand_port_list(&inter.input);
+                    let raw_sinks = expand_port_list(&inter.output);
                     let sources =
                         resolve_bus_list(&raw_sources, &pb_type.name, &my_ports, &children_ports);
                     let sinks =

--- a/fpga_arch_viewer/src/intra_tile.rs
+++ b/fpga_arch_viewer/src/intra_tile.rs
@@ -237,7 +237,7 @@ pub fn expand_all_blocks(state: &mut IntraTileState, pb_type: &PBType, instance_
 
     for child_pb in children {
         for i in 0..child_pb.num_pb {
-            let instance_name = generate_child_instance_name(child_pb, i as usize);
+            let instance_name = generate_child_instance_name(child_pb, i);
             let child_path = format!("{}.{}", instance_path, instance_name);
             expand_all_blocks(state, child_pb, &child_path);
         }
@@ -449,12 +449,12 @@ fn measure_pb_type(
 
             for child_pb in children {
                 let num = child_pb.num_pb as f32;
-                let gaps = std::cmp::max(child_pb.num_pb - 1, 0) as f32;
+                let gaps = child_pb.num_pb.saturating_sub(1) as f32;
 
                 let mut max_instance_size = egui::vec2(0.0, 0.0);
 
                 for i in 0..child_pb.num_pb {
-                    let child_instance_name = generate_child_instance_name(child_pb, i as usize);
+                    let child_instance_name = generate_child_instance_name(child_pb, i);
                     let child_path = format!("{}.{}", instance_path, child_instance_name);
                     let s = measure_pb_type(child_pb, state, &child_path);
                     max_instance_size = max_instance_size.max(s);
@@ -478,11 +478,11 @@ fn measure_pb_type(
 
             for child_pb in children {
                 let num = child_pb.num_pb as f32;
-                let gaps = std::cmp::max(child_pb.num_pb - 1, 0) as f32;
+                let gaps = child_pb.num_pb.saturating_sub(1) as f32;
 
                 let mut max_instance_size = egui::vec2(0.0, 0.0);
                 for i in 0..child_pb.num_pb {
-                    let child_instance_name = generate_child_instance_name(child_pb, i as usize);
+                    let child_instance_name = generate_child_instance_name(child_pb, i);
                     let child_path = format!("{}.{}", instance_path, child_instance_name);
                     let s = measure_pb_type(child_pb, state, &child_path);
                     max_instance_size = max_instance_size.max(s);
@@ -1101,7 +1101,7 @@ fn draw_pb_type(
         for child_pb in children {
             let mut max_col_width: f32 = 0.0;
             for i in 0..child_pb.num_pb {
-                let instance_name = generate_child_instance_name(child_pb, i as usize);
+                let instance_name = generate_child_instance_name(child_pb, i);
                 let child_path = format!("{}.{}", instance_path, instance_name);
 
                 let child_single_size = measure_pb_type(child_pb, state, &child_path);

--- a/fpga_arch_viewer/src/intra_tile.rs
+++ b/fpga_arch_viewer/src/intra_tile.rs
@@ -509,10 +509,12 @@ fn measure_pb_type(
     let max_pins = total_input_pins.max(total_output_pins) as f32;
     let min_port_height = (max_pins + 1.0) * (MIN_PIN_SPACING * zoom);
 
-    let has_complete_interconnect = pb_type
-        .interconnects
-        .iter()
-        .any(|i| matches!(i.interconnect_type, fpga_arch_parser::InterconnectType::Complete));
+    let has_complete_interconnect = pb_type.interconnects.iter().any(|i| {
+        matches!(
+            i.interconnect_type,
+            fpga_arch_parser::InterconnectType::Complete
+        )
+    });
 
     let is_clock_complete = pb_type
         .interconnects
@@ -723,7 +725,10 @@ fn is_clock_complete_interconnect(
     current_pb: &PBType,
     children: &[PBType],
 ) -> bool {
-    if matches!(interconnect.interconnect_type, fpga_arch_parser::InterconnectType::Complete) {
+    if matches!(
+        interconnect.interconnect_type,
+        fpga_arch_parser::InterconnectType::Complete
+    ) {
         // Expand port lists to get individual port references
         let raw_inputs = expand_port_list(&interconnect.input);
         let raw_outputs = expand_port_list(&interconnect.output);
@@ -912,10 +917,12 @@ fn draw_pb_type(
     let children = get_children_for_mode(pb_type, mode_index);
 
     let has_children = !children.is_empty();
-    let has_complete_interconnect = pb_type
-        .interconnects
-        .iter()
-        .any(|i| matches!(i.interconnect_type, fpga_arch_parser::InterconnectType::Complete));
+    let has_complete_interconnect = pb_type.interconnects.iter().any(|i| {
+        matches!(
+            i.interconnect_type,
+            fpga_arch_parser::InterconnectType::Complete
+        )
+    });
     let _is_clock_complete = pb_type
         .interconnects
         .iter()

--- a/fpga_arch_viewer/src/intra_tile.rs
+++ b/fpga_arch_viewer/src/intra_tile.rs
@@ -987,7 +987,10 @@ fn draw_pb_type(
         PBTypeClass::Memory => {
             intra_block_drawing::draw_memory(painter, rect, pb_type, state, ui, dark_mode)
         }
-        PBTypeClass::None => {
+        PBTypeClass::None
+        | PBTypeClass::InterconnectDirect
+        | PBTypeClass::InterconnectMux
+        | PBTypeClass::InterconnectComplete => {
             if pb_type.blif_model.is_some() {
                 intra_block_drawing::draw_blif_block(painter, rect, pb_type, state, ui, dark_mode)
             } else {

--- a/fpga_arch_viewer/src/primitive_view.rs
+++ b/fpga_arch_viewer/src/primitive_view.rs
@@ -130,7 +130,7 @@ impl<'a> DelayLookup<'a> {
     }
 
     /// Look up the pin count for a named port in the pb_type's port list.
-    fn port_num_pins(&self, name: &str) -> Option<i32> {
+    fn port_num_pins(&self, name: &str) -> Option<usize> {
         self.pb_type.ports.iter().find_map(|p| {
             let (port_name, num_pins) = match p {
                 Port::Input(ip) => (ip.name.as_str(), ip.num_pins),
@@ -313,12 +313,12 @@ impl<'a> DelayLookup<'a> {
 /// Returns a warning string if multiple per-pin constraints were found but fewer than expected,
 /// or `None` if the count is satisfactory. A single found value is never warned (treated as a
 /// scalar constraint covering all pins).
-fn partial_warning(label: &str, found: usize, expected: Option<i32>) -> Option<String> {
+fn partial_warning(label: &str, found: usize, expected: Option<usize>) -> Option<String> {
     if let Some(exp) = expected
         && found > 1
-        && found < exp as usize
+        && found < exp
     {
-        let missing = exp as usize - found;
+        let missing = exp - found;
         return Some(format!("⚠ {missing} of {exp} pins have no {label}"));
     }
     None
@@ -332,7 +332,7 @@ fn partial_warning(label: &str, found: usize, expected: Option<i32>) -> Option<S
 /// - N diff  → `"<label> = 60.00 – 80.00 ps  (N pins)"`
 ///
 /// Appends a partial-annotation warning line when `found > 1` and `found < expected`.
-fn format_scalar_pins(label: &str, values: &[f32], expected: Option<i32>) -> String {
+fn format_scalar_pins(label: &str, values: &[f32], expected: Option<usize>) -> String {
     if values.is_empty() {
         return format!("{label} = ⚠ MISSING");
     }
@@ -360,7 +360,7 @@ fn format_scalar_pins(label: &str, values: &[f32], expected: Option<i32>) -> Str
 /// Format a collection of `(min, max)` clock-to-Q pin pairs under `label`.
 ///
 /// Follows the same compact / range / partial-warning rules as `format_scalar_pins`.
-fn format_ctq_pins(label: &str, pairs: &[(f32, f32)], expected: Option<i32>) -> String {
+fn format_ctq_pins(label: &str, pairs: &[(f32, f32)], expected: Option<usize>) -> String {
     if pairs.is_empty() {
         return format!("{label} = ⚠ MISSING");
     }
@@ -434,7 +434,7 @@ fn build_setup_hold_annotation(
 }
 
 /// Format a one-line port description: `"y  (40 pins)"` or just `"y"`.
-fn port_header(name: &str, num_pins: Option<i32>) -> String {
+fn port_header(name: &str, num_pins: Option<usize>) -> String {
     match num_pins {
         Some(n) => format!("{name}  ({n} pins)"),
         None => name.to_string(),


### PR DESCRIPTION
Working on improving the visualization of the complex blocks. The first step for doing that is improving the parser so the complex block interconnect and hierarchy is parsed into a graph structure that is easier to work with for visualization.

This is related to #117 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hierarchical complex block graph support to represent blocks, modes, ports, pins and interconnect nets.

* **Refactor**
  * Unified interconnect representation into a single structure with explicit type discrimination and standardized shared fields.
  * Exposed complex block graphs on the parsed architecture.

* **Behavior / UI**
  * Updated visualization/rendering to use the new interconnect model and classification.

* **Tests**
  * Added comprehensive integration tests validating complex block graph construction and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->