### PR TITLE
[Web] Fixed caching issues

### DIFF
--- a/fpga_arch_viewer/assets/sw.js
+++ b/fpga_arch_viewer/assets/sw.js
@@ -13,6 +13,9 @@ self.addEventListener('install', function (e) {
             return cache.addAll(filesToCache);
         })
     );
+    /* Skip waiting so the new service worker activates immediately on update,
+       rather than waiting for all existing tabs to be closed first. */
+    self.skipWaiting();
 });
 
 self.addEventListener('activate', function (e) {


### PR DESCRIPTION
I found that the cache was not automatically being refreshed on releases, causing people to always see the old version of the web app if it was in the cache. Added a small fix which should refresh the cache if the cachename is different (i.e. there is a new release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service worker update behavior to apply new versions more immediately after installation, enhancing the app's ability to quickly roll out important updates without requiring users to close and reopen the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->