### PR TITLE
[Viewer] Added Scroll Regions to Side Bars

### DIFF
--- a/fpga_arch_viewer/src/complex_block_view.rs
+++ b/fpga_arch_viewer/src/complex_block_view.rs
@@ -95,16 +95,24 @@ impl ComplexBlockView {
     }
 
     fn render_side_panel(&mut self, arch: &FPGAArch, ctx: &egui::Context) {
-        let should_expand_all = render_intra_tile_controls_panel(
-            ctx,
-            arch,
-            &mut self.complex_block_view_state.all_blocks_expanded,
-            &mut self.complex_block_view_state.draw_intra_interconnects,
-            &mut self.complex_block_view_state.selected_complex_block_name,
-        );
-        if should_expand_all {
-            self.apply_expand_all_state(arch);
-        }
+        egui::SidePanel::right("complex_block_controls")
+            .default_width(250.0)
+            .show(ctx, |ui| {
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        let should_expand_all = render_intra_tile_controls_panel(
+                            ui,
+                            arch,
+                            &mut self.complex_block_view_state.all_blocks_expanded,
+                            &mut self.complex_block_view_state.draw_intra_interconnects,
+                            &mut self.complex_block_view_state.selected_complex_block_name,
+                        );
+                        if should_expand_all {
+                            self.apply_expand_all_state(arch);
+                        }
+                    });
+            });
     }
 
     fn apply_expand_all_state(&mut self, arch: &FPGAArch) {
@@ -129,7 +137,7 @@ impl ComplexBlockView {
 
 /// Renders the intra-tile view controls panel on the right side
 fn render_intra_tile_controls_panel(
-    ctx: &egui::Context,
+    ui: &mut egui::Ui,
     arch: &FPGAArch,
     all_blocks_expanded: &mut bool,
     draw_intra_interconnects: &mut bool,
@@ -137,66 +145,60 @@ fn render_intra_tile_controls_panel(
 ) -> bool {
     let mut expand_all = false;
 
-    egui::SidePanel::right("complex_block_controls")
-        .default_width(250.0)
-        .show(ctx, |ui| {
-            ui.heading("Complex Block View");
-            ui.add_space(10.0);
+    ui.heading("Complex Block View");
+    ui.add_space(10.0);
 
-            // Expand All toggle
-            let mut expand_all_toggle_val = *all_blocks_expanded;
-            if ui
-                .checkbox(&mut expand_all_toggle_val, "Expand All")
-                .changed()
-            {
-                *all_blocks_expanded = expand_all_toggle_val;
-                expand_all = true;
-            }
+    // Expand All toggle
+    let mut expand_all_toggle_val = *all_blocks_expanded;
+    if ui
+        .checkbox(&mut expand_all_toggle_val, "Expand All")
+        .changed()
+    {
+        *all_blocks_expanded = expand_all_toggle_val;
+        expand_all = true;
+    }
 
-            // Interconnect toggle
-            ui.checkbox(draw_intra_interconnects, "Draw Interconnects");
+    // Interconnect toggle
+    ui.checkbox(draw_intra_interconnects, "Draw Interconnects");
 
-            ui.add_space(10.0);
-            ui.separator();
-            ui.add_space(10.0);
+    ui.add_space(10.0);
+    ui.separator();
+    ui.add_space(10.0);
 
-            // Tile selector
-            if !arch.complex_block_list.is_empty() {
-                ui.label("Select Complex Block:");
-                ui.add_space(5.0);
+    // Tile selector
+    if !arch.complex_block_list.is_empty() {
+        ui.label("Select Complex Block:");
+        ui.add_space(5.0);
 
-                let mut selected_complex_block_name_str = selected_complex_block_name
-                    .as_deref()
-                    .unwrap_or("")
-                    .to_string();
+        let mut selected_complex_block_name_str = selected_complex_block_name
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
 
-                egui::ComboBox::from_id_salt("complex_block_selector")
-                    .selected_text(if !selected_complex_block_name_str.is_empty() {
-                        selected_complex_block_name_str.as_str()
-                    } else {
-                        "Select a complex block"
-                    })
-                    .show_ui(ui, |ui| {
-                        for pb_type in &arch.complex_block_list {
-                            ui.selectable_value(
-                                &mut selected_complex_block_name_str,
-                                pb_type.name.clone(),
-                                &pb_type.name,
-                            );
-                        }
-                    });
-
-                // If tile selection changed, update state
-                if selected_complex_block_name_str
-                    != selected_complex_block_name.as_deref().unwrap_or("")
-                {
-                    *selected_complex_block_name = Some(selected_complex_block_name_str);
-                    expand_all = true;
-                }
+        egui::ComboBox::from_id_salt("complex_block_selector")
+            .selected_text(if !selected_complex_block_name_str.is_empty() {
+                selected_complex_block_name_str.as_str()
             } else {
-                ui.label("No complex blocks available in architecture");
-            }
-        });
+                "Select a complex block"
+            })
+            .show_ui(ui, |ui| {
+                for pb_type in &arch.complex_block_list {
+                    ui.selectable_value(
+                        &mut selected_complex_block_name_str,
+                        pb_type.name.clone(),
+                        &pb_type.name,
+                    );
+                }
+            });
+
+        // If tile selection changed, update state
+        if selected_complex_block_name_str != selected_complex_block_name.as_deref().unwrap_or("") {
+            *selected_complex_block_name = Some(selected_complex_block_name_str);
+            expand_all = true;
+        }
+    } else {
+        ui.label("No complex blocks available in architecture");
+    }
 
     expand_all
 }

--- a/fpga_arch_viewer/src/crr_sb_view.rs
+++ b/fpga_arch_viewer/src/crr_sb_view.rs
@@ -129,7 +129,11 @@ impl CRRSBView {
         egui::SidePanel::right("crr_view_controls")
             .default_width(250.0)
             .show(ctx, |ui| {
-                self.render_side_panel(arch, ui);
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        self.render_side_panel(arch, ui);
+                    });
             });
         egui::CentralPanel::default().show(ctx, |ui| {
             self.render_central_panel(arch, tile_colors, ui);

--- a/fpga_arch_viewer/src/grid_view.rs
+++ b/fpga_arch_viewer/src/grid_view.rs
@@ -221,23 +221,31 @@ impl GridView {
     }
 
     fn render_side_panel(&mut self, arch: &FPGAArch, ctx: &egui::Context) {
-        let grid_changed = render_grid_controls_panel(
-            ctx,
-            arch,
-            &mut self.grid_state,
-            self.device_grid.as_ref(),
-            &self.tile_colors,
-        );
-        if grid_changed {
-            self.rebuild_grid(arch);
-        }
+        egui::SidePanel::right("grid_controls")
+            .default_width(250.0)
+            .show(ctx, |ui| {
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        let grid_changed = render_grid_controls_panel(
+                            ui,
+                            arch,
+                            &mut self.grid_state,
+                            self.device_grid.as_ref(),
+                            &self.tile_colors,
+                        );
+                        if grid_changed {
+                            self.rebuild_grid(arch);
+                        }
+                    });
+            });
     }
 }
 
 /// Renders the grid controls panel on the right side
 /// Returns true if grid dimensions changed
 fn render_grid_controls_panel(
-    ctx: &egui::Context,
+    ui: &mut egui::Ui,
     arch: &FPGAArch,
     state: &mut GridState,
     device_grid: Option<&DeviceGrid>,
@@ -245,263 +253,249 @@ fn render_grid_controls_panel(
 ) -> bool {
     let mut grid_changed = false;
 
-    egui::SidePanel::right("grid_controls")
-        .default_width(250.0)
-        .show(ctx, |ui| {
-            ui.heading("Grid Settings");
-            ui.add_space(10.0);
+    ui.heading("Grid Settings");
+    ui.add_space(10.0);
 
-            // Layout selection dropdown
-            if arch.layouts.layout_list.len() > 1 {
-                ui.label("Layout:");
-                let mut layout_changed = false;
-                egui::ComboBox::from_id_salt("layout_selector")
-                    .selected_text(get_layout_name(arch, state.selected_layout_index))
-                    .show_ui(ui, |ui| {
-                        for (idx, layout) in arch.layouts.layout_list.iter().enumerate() {
-                            let layout_name = match &layout {
-                                fpga_arch_parser::Layout::AutoLayout(_) => {
-                                    "Auto Layout".to_string()
-                                }
-                                fpga_arch_parser::Layout::FixedLayout(fl) => {
-                                    format!("Fixed: {}", fl.name)
-                                }
-                            };
-                            if ui
-                                .selectable_value(
-                                    &mut state.selected_layout_index,
-                                    idx,
-                                    layout_name,
-                                )
-                                .clicked()
-                            {
-                                layout_changed = true;
-                            }
+    // Layout selection dropdown
+    if arch.layouts.layout_list.len() > 1 {
+        ui.label("Layout:");
+        let mut layout_changed = false;
+        egui::ComboBox::from_id_salt("layout_selector")
+            .selected_text(get_layout_name(arch, state.selected_layout_index))
+            .show_ui(ui, |ui| {
+                for (idx, layout) in arch.layouts.layout_list.iter().enumerate() {
+                    let layout_name = match &layout {
+                        fpga_arch_parser::Layout::AutoLayout(_) => "Auto Layout".to_string(),
+                        fpga_arch_parser::Layout::FixedLayout(fl) => {
+                            format!("Fixed: {}", fl.name)
                         }
-                    });
+                    };
+                    if ui
+                        .selectable_value(&mut state.selected_layout_index, idx, layout_name)
+                        .clicked()
+                    {
+                        layout_changed = true;
+                    }
+                }
+            });
 
-                if layout_changed {
+        if layout_changed {
+            grid_changed = true;
+            state.selected_die_id = 0;
+        }
+        ui.add_space(10.0);
+    }
+
+    // Check if current layout is fixed
+    let is_fixed_layout = matches!(
+        arch.layouts.layout_list.get(state.selected_layout_index),
+        Some(fpga_arch_parser::Layout::FixedLayout { .. })
+    );
+
+    ui.label(if is_fixed_layout {
+        "Dimensions (Fixed by layout):"
+    } else {
+        "Adjust dimensions while maintaining aspect ratio:"
+    });
+    ui.add_space(10.0);
+
+    // Width slider and text input
+    ui.horizontal(|ui| {
+        ui.label("Width:");
+        let mut temp_width = state.grid_width as f64;
+        ui.add_enabled_ui(!is_fixed_layout, |ui| {
+            if ui
+                .add(
+                    egui::Slider::new(&mut temp_width, 1.0..=100.0)
+                        .step_by(1.0)
+                        .show_value(false),
+                )
+                .changed()
+            {
+                let new_width = temp_width.round() as usize;
+                if new_width != state.grid_width && new_width >= 1 {
+                    state.grid_width = new_width;
+                    update_grid_height_from_width(state);
                     grid_changed = true;
-                    state.selected_die_id = 0;
-                }
-                ui.add_space(10.0);
-            }
-
-            // Check if current layout is fixed
-            let is_fixed_layout = matches!(
-                arch.layouts.layout_list.get(state.selected_layout_index),
-                Some(fpga_arch_parser::Layout::FixedLayout { .. })
-            );
-
-            ui.label(if is_fixed_layout {
-                "Dimensions (Fixed by layout):"
-            } else {
-                "Adjust dimensions while maintaining aspect ratio:"
-            });
-            ui.add_space(10.0);
-
-            // Width slider and text input
-            ui.horizontal(|ui| {
-                ui.label("Width:");
-                let mut temp_width = state.grid_width as f64;
-                ui.add_enabled_ui(!is_fixed_layout, |ui| {
-                    if ui
-                        .add(
-                            egui::Slider::new(&mut temp_width, 1.0..=100.0)
-                                .step_by(1.0)
-                                .show_value(false),
-                        )
-                        .changed()
-                    {
-                        let new_width = temp_width.round() as usize;
-                        if new_width != state.grid_width && new_width >= 1 {
-                            state.grid_width = new_width;
-                            update_grid_height_from_width(state);
-                            grid_changed = true;
-                        }
-                    }
-                });
-            });
-
-            ui.indent("width_entry", |ui| {
-                let mut width_text = state.grid_width.to_string();
-                ui.add_enabled_ui(!is_fixed_layout, |ui| {
-                    if ui
-                        .add(egui::TextEdit::singleline(&mut width_text).desired_width(60.0))
-                        .changed()
-                        && let Ok(new_width) = width_text.parse::<usize>()
-                        && (1..=100).contains(&new_width)
-                        && new_width != state.grid_width
-                    {
-                        state.grid_width = new_width;
-                        update_grid_height_from_width(state);
-                        grid_changed = true;
-                    }
-                });
-            });
-
-            ui.add_space(10.0);
-
-            // Height slider and text input
-            ui.horizontal(|ui| {
-                ui.label("Height:");
-                let mut temp_height = state.grid_height as f64;
-                ui.add_enabled_ui(!is_fixed_layout, |ui| {
-                    if ui
-                        .add(
-                            egui::Slider::new(&mut temp_height, 1.0..=100.0)
-                                .step_by(1.0)
-                                .show_value(false),
-                        )
-                        .changed()
-                    {
-                        let new_height = temp_height.round() as usize;
-                        if new_height != state.grid_height && new_height >= 1 {
-                            state.grid_height = new_height;
-                            update_grid_width_from_height(state);
-                            grid_changed = true;
-                        }
-                    }
-                });
-            });
-
-            ui.indent("height_entry", |ui| {
-                let mut height_text = state.grid_height.to_string();
-                ui.add_enabled_ui(!is_fixed_layout, |ui| {
-                    if ui
-                        .add(egui::TextEdit::singleline(&mut height_text).desired_width(60.0))
-                        .changed()
-                        && let Ok(new_height) = height_text.parse::<usize>()
-                        && (1..=100).contains(&new_height)
-                        && new_height != state.grid_height
-                    {
-                        state.grid_height = new_height;
-                        update_grid_width_from_height(state);
-                        grid_changed = true;
-                    }
-                });
-            });
-
-            if let Some(layout) = arch.layouts.layout_list.get(state.selected_layout_index) {
-                let layers = match layout {
-                    fpga_arch_parser::Layout::FixedLayout(fixed_layout) => &fixed_layout.layers,
-                    fpga_arch_parser::Layout::AutoLayout(auto_layout) => &auto_layout.layers,
-                };
-
-                if layers.len() > 1 {
-                    ui.add_space(10.0);
-                    let selected_layer_name = format!("Layer {}", state.selected_die_id);
-                    ui.label("Layer:");
-                    egui::ComboBox::from_id_salt("layer_selector")
-                        .selected_text(&selected_layer_name)
-                        .show_ui(ui, |ui| {
-                            for die_id in 0..layers.len() {
-                                let layer_name = format!("Layer {}", die_id);
-                                if ui
-                                    .selectable_value(
-                                        &mut state.selected_die_id,
-                                        die_id,
-                                        layer_name,
-                                    )
-                                    .clicked()
-                                {}
-                            }
-                        });
                 }
             }
+        });
+    });
 
-            ui.add_space(15.0);
-            ui.separator();
-            ui.add_space(10.0);
-
-            ui.label(format!("Aspect Ratio: {:.2}", state.aspect_ratio));
-            ui.label(format!(
-                "Grid Size: {}x{}",
-                state.grid_width, state.grid_height
-            ));
-
-            if arch.noc.is_some() {
-                ui.add_space(15.0);
-                ui.separator();
-                ui.add_space(10.0);
-
-                ui.checkbox(&mut state.show_noc, "Show NoC");
+    ui.indent("width_entry", |ui| {
+        let mut width_text = state.grid_width.to_string();
+        ui.add_enabled_ui(!is_fixed_layout, |ui| {
+            if ui
+                .add(egui::TextEdit::singleline(&mut width_text).desired_width(60.0))
+                .changed()
+                && let Ok(new_width) = width_text.parse::<usize>()
+                && (1..=100).contains(&new_width)
+                && new_width != state.grid_width
+            {
+                state.grid_width = new_width;
+                update_grid_height_from_width(state);
+                grid_changed = true;
             }
+        });
+    });
 
-            ui.add_space(15.0);
-            ui.separator();
+    ui.add_space(10.0);
+
+    // Height slider and text input
+    ui.horizontal(|ui| {
+        ui.label("Height:");
+        let mut temp_height = state.grid_height as f64;
+        ui.add_enabled_ui(!is_fixed_layout, |ui| {
+            if ui
+                .add(
+                    egui::Slider::new(&mut temp_height, 1.0..=100.0)
+                        .step_by(1.0)
+                        .show_value(false),
+                )
+                .changed()
+            {
+                let new_height = temp_height.round() as usize;
+                if new_height != state.grid_height && new_height >= 1 {
+                    state.grid_height = new_height;
+                    update_grid_width_from_height(state);
+                    grid_changed = true;
+                }
+            }
+        });
+    });
+
+    ui.indent("height_entry", |ui| {
+        let mut height_text = state.grid_height.to_string();
+        ui.add_enabled_ui(!is_fixed_layout, |ui| {
+            if ui
+                .add(egui::TextEdit::singleline(&mut height_text).desired_width(60.0))
+                .changed()
+                && let Ok(new_height) = height_text.parse::<usize>()
+                && (1..=100).contains(&new_height)
+                && new_height != state.grid_height
+            {
+                state.grid_height = new_height;
+                update_grid_width_from_height(state);
+                grid_changed = true;
+            }
+        });
+    });
+
+    if let Some(layout) = arch.layouts.layout_list.get(state.selected_layout_index) {
+        let layers = match layout {
+            fpga_arch_parser::Layout::FixedLayout(fixed_layout) => &fixed_layout.layers,
+            fpga_arch_parser::Layout::AutoLayout(auto_layout) => &auto_layout.layers,
+        };
+
+        if layers.len() > 1 {
             ui.add_space(10.0);
+            let selected_layer_name = format!("Layer {}", state.selected_die_id);
+            ui.label("Layer:");
+            egui::ComboBox::from_id_salt("layer_selector")
+                .selected_text(&selected_layer_name)
+                .show_ui(ui, |ui| {
+                    for die_id in 0..layers.len() {
+                        let layer_name = format!("Layer {}", die_id);
+                        if ui
+                            .selectable_value(&mut state.selected_die_id, die_id, layer_name)
+                            .clicked()
+                        {}
+                    }
+                });
+        }
+    }
 
-            ui.horizontal(|ui| {
-                ui.label("Zoom:");
-                if ui.small_button("−").clicked() {
-                    state.zoom_out(1.1);
+    ui.add_space(15.0);
+    ui.separator();
+    ui.add_space(10.0);
+
+    ui.label(format!("Aspect Ratio: {:.2}", state.aspect_ratio));
+    ui.label(format!(
+        "Grid Size: {}x{}",
+        state.grid_width, state.grid_height
+    ));
+
+    if arch.noc.is_some() {
+        ui.add_space(15.0);
+        ui.separator();
+        ui.add_space(10.0);
+
+        ui.checkbox(&mut state.show_noc, "Show NoC");
+    }
+
+    ui.add_space(15.0);
+    ui.separator();
+    ui.add_space(10.0);
+
+    ui.horizontal(|ui| {
+        ui.label("Zoom:");
+        if ui.small_button("−").clicked() {
+            state.zoom_out(1.1);
+        }
+        ui.label(format!("{:.0}%", state.zoom_factor * 100.0));
+        if ui.small_button("+").clicked() {
+            state.zoom_in(1.1);
+        }
+        if ui.small_button("Reset").clicked() {
+            state.reset_zoom();
+        }
+    });
+
+    ui.add_space(15.0);
+    ui.separator();
+    ui.add_space(10.0);
+
+    // Tile counts table
+    ui.heading("Tile Counts");
+    ui.add_space(10.0);
+
+    if let Some(grid) = device_grid {
+        let mut tile_counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for row in &grid.grid_layers[state.selected_die_id].cells {
+            for cell in row {
+                if let GridCell::BlockAnchor { pb_type, .. } = cell {
+                    *tile_counts.entry(pb_type.clone()).or_insert(0) += 1;
                 }
-                ui.label(format!("{:.0}%", state.zoom_factor * 100.0));
-                if ui.small_button("+").clicked() {
-                    state.zoom_in(1.1);
-                }
-                if ui.small_button("Reset").clicked() {
-                    state.reset_zoom();
-                }
+            }
+        }
+
+        let sorted_counts: Vec<_> = tile_counts.into_iter().collect();
+
+        let table = egui_extras::TableBuilder::new(ui)
+            .striped(true)
+            .column(egui_extras::Column::auto().at_least(100.0))
+            .column(egui_extras::Column::auto().at_least(50.0))
+            .header(20.0, |mut header| {
+                header.col(|ui| {
+                    ui.strong("Tile");
+                });
+                header.col(|ui| {
+                    ui.strong("Count");
+                });
             });
 
-            ui.add_space(15.0);
-            ui.separator();
-            ui.add_space(10.0);
-
-            // Tile counts table
-            ui.heading("Tile Counts");
-            ui.add_space(10.0);
-
-            if let Some(grid) = device_grid {
-                let mut tile_counts: std::collections::BTreeMap<String, usize> =
-                    std::collections::BTreeMap::new();
-                for row in &grid.grid_layers[state.selected_die_id].cells {
-                    for cell in row {
-                        if let GridCell::BlockAnchor { pb_type, .. } = cell {
-                            *tile_counts.entry(pb_type.clone()).or_insert(0) += 1;
-                        }
-                    }
-                }
-
-                let sorted_counts: Vec<_> = tile_counts.into_iter().collect();
-
-                let table = egui_extras::TableBuilder::new(ui)
-                    .striped(true)
-                    .column(egui_extras::Column::auto().at_least(100.0))
-                    .column(egui_extras::Column::auto().at_least(50.0))
-                    .header(20.0, |mut header| {
-                        header.col(|ui| {
-                            ui.strong("Tile");
-                        });
-                        header.col(|ui| {
-                            ui.strong("Count");
-                        });
+        table.body(|mut body| {
+            for (pb_type, count) in sorted_counts {
+                let color = tile_colors
+                    .get(&pb_type)
+                    .copied()
+                    .unwrap_or(egui::Color32::TRANSPARENT);
+                body.row(30.0, |mut row| {
+                    row.col(|ui| {
+                        let rect = ui.available_rect_before_wrap();
+                        ui.painter().rect_filled(rect, 0.0, color);
+                        ui.label(pb_type.to_uppercase());
                     });
-
-                table.body(|mut body| {
-                    for (pb_type, count) in sorted_counts {
-                        let color = tile_colors
-                            .get(&pb_type)
-                            .copied()
-                            .unwrap_or(egui::Color32::TRANSPARENT);
-                        body.row(30.0, |mut row| {
-                            row.col(|ui| {
-                                let rect = ui.available_rect_before_wrap();
-                                ui.painter().rect_filled(rect, 0.0, color);
-                                ui.label(pb_type.to_uppercase());
-                            });
-                            row.col(|ui| {
-                                let rect = ui.available_rect_before_wrap();
-                                ui.painter().rect_filled(rect, 0.0, color);
-                                ui.label(count.to_string());
-                            });
-                        });
-                    }
+                    row.col(|ui| {
+                        let rect = ui.available_rect_before_wrap();
+                        ui.painter().rect_filled(rect, 0.0, color);
+                        ui.label(count.to_string());
+                    });
                 });
             }
         });
+    }
 
     grid_changed
 }

--- a/fpga_arch_viewer/src/grid_view.rs
+++ b/fpga_arch_viewer/src/grid_view.rs
@@ -463,6 +463,7 @@ fn render_grid_controls_panel(
         let sorted_counts: Vec<_> = tile_counts.into_iter().collect();
 
         let table = egui_extras::TableBuilder::new(ui)
+            .vscroll(false)
             .striped(true)
             .column(egui_extras::Column::auto().at_least(100.0))
             .column(egui_extras::Column::auto().at_least(50.0))

--- a/fpga_arch_viewer/src/primitive_view.rs
+++ b/fpga_arch_viewer/src/primitive_view.rs
@@ -665,7 +665,11 @@ impl PrimitiveView {
         egui::SidePanel::right("primitive_view_controls")
             .default_width(250.0)
             .show(ctx, |ui| {
-                self.render_side_panel(arch, &pb_type_matches, ui);
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        self.render_side_panel(arch, &pb_type_matches, ui);
+                    });
             });
 
         egui::CentralPanel::default().show(ctx, |ui| {

--- a/fpga_arch_viewer/src/tile_view.rs
+++ b/fpga_arch_viewer/src/tile_view.rs
@@ -34,7 +34,11 @@ impl TileView {
         egui::SidePanel::right("tile_view_controls")
             .default_width(250.0)
             .show(ctx, |ui| {
-                self.render_side_panel(arch, ui);
+                egui::ScrollArea::vertical()
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        self.render_side_panel(arch, ui);
+                    });
             });
 
         egui::CentralPanel::default().show(ctx, |ui| {


### PR DESCRIPTION
When presenting the viewer in the browser, some people said that they found it dificult to use the side bars when the screen height is too small. Added Scroll regions to make this easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Side panels in multiple views now properly support vertical scrolling when content exceeds available space, ensuring all controls remain accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->