### PR TITLE
[Visualizer] Fix Dark Mode for Tile Rendering

### DIFF
--- a/fpga_arch_viewer/src/block_style.rs
+++ b/fpga_arch_viewer/src/block_style.rs
@@ -63,8 +63,27 @@ pub fn get_default_color_palette() -> Vec<Color32> {
     ]
 }
 
-pub fn get_tile_color(_tile_name: &str, tile_index: usize) -> Color32 {
-    let palette = get_default_color_palette();
+pub fn get_dark_color_palette() -> Vec<Color32> {
+    vec![
+        Color32::from_rgb(60, 80, 120),  // Dark Blue
+        Color32::from_rgb(80, 80, 80),   // Dark Gray
+        Color32::from_rgb(120, 90, 60),  // Dark Orange
+        Color32::from_rgb(120, 110, 70), // Dark Yellow
+        Color32::from_rgb(60, 100, 65),  // Dark Green
+        Color32::from_rgb(90, 65, 100),  // Dark Purple
+        Color32::from_rgb(120, 65, 65),  // Dark Pink
+        Color32::from_rgb(55, 95, 105),  // Dark Cyan
+        Color32::from_rgb(100, 95, 50),  // Dark Amber
+        Color32::from_rgb(80, 90, 55),   // Dark Lime
+    ]
+}
+
+pub fn get_tile_color(_tile_name: &str, tile_index: usize, dark_mode: bool) -> Color32 {
+    let palette = if dark_mode {
+        get_dark_color_palette()
+    } else {
+        get_default_color_palette()
+    };
     palette[tile_index % palette.len()]
 }
 

--- a/fpga_arch_viewer/src/color_scheme.rs
+++ b/fpga_arch_viewer/src/color_scheme.rs
@@ -215,3 +215,16 @@ pub fn grid_cb_color(dark_mode: bool) -> egui::Color32 {
         egui::Color32::from_rgb(0xFF, 0xF3, 0xCC) // #FFF3CC - Light yellow
     }
 }
+
+// ----------------------------------------------------------------------------
+// CRR Switch Block View Colors
+// ----------------------------------------------------------------------------
+
+/// Wire/channel stroke color for the CRR Switch Block view
+pub fn crr_wire_color(dark_mode: bool) -> egui::Color32 {
+    if dark_mode {
+        egui::Color32::WHITE
+    } else {
+        egui::Color32::BLACK
+    }
+}

--- a/fpga_arch_viewer/src/crr_sb_view.rs
+++ b/fpga_arch_viewer/src/crr_sb_view.rs
@@ -124,6 +124,7 @@ impl CRRSBView {
         &mut self,
         arch: &FPGAArch,
         tile_colors: &HashMap<String, egui::Color32>,
+        dark_mode: bool,
         ctx: &egui::Context,
     ) {
         egui::SidePanel::right("crr_view_controls")
@@ -136,7 +137,7 @@ impl CRRSBView {
                     });
             });
         egui::CentralPanel::default().show(ctx, |ui| {
-            self.render_central_panel(arch, tile_colors, ui);
+            self.render_central_panel(arch, tile_colors, dark_mode, ui);
         });
     }
 
@@ -206,6 +207,7 @@ impl CRRSBView {
         &mut self,
         arch: &FPGAArch,
         tile_colors: &HashMap<String, egui::Color32>,
+        dark_mode: bool,
         ui: &mut egui::Ui,
     ) {
         if let Some(error_msg) = &self.last_error {
@@ -240,7 +242,7 @@ impl CRRSBView {
             {
                 let grid =
                     DeviceGrid::from_fixed_layout(arch, self.crr_view_state.selected_layout_index);
-                self.render_crr_sb(&grid, arch, tile_colors, ui);
+                self.render_crr_sb(&grid, arch, tile_colors, dark_mode, ui);
             }
             // } else if let Some(error_msg) = &self.last_error {
             //     ui.colored_label(egui::Color32::RED, format!("Error: {}", error_msg));
@@ -295,6 +297,7 @@ impl CRRSBView {
         grid: &DeviceGrid,
         arch: &FPGAArch,
         tile_colors: &HashMap<String, egui::Color32>,
+        dark_mode: bool,
         ui: &mut egui::Ui,
     ) {
         egui::ScrollArea::both()
@@ -360,10 +363,10 @@ impl CRRSBView {
 
                     let tile_lb_color = match tile_colors.get(&tile.name) {
                         Some(c) => *c,
-                        None => color_scheme::grid_cb_color(false),
+                        None => color_scheme::grid_cb_color(dark_mode),
                     };
                     let logic_block_renderer =
-                        build_render_tile(tile, &tile_lb_rect, &tile_lb_color);
+                        build_render_tile(tile, &tile_lb_rect, &tile_lb_color, dark_mode);
                     render_tile_lookup.insert(tile.name.clone(), logic_block_renderer);
 
                     tile_object_lookup.insert(tile.name.clone(), tile);

--- a/fpga_arch_viewer/src/crr_sb_view.rs
+++ b/fpga_arch_viewer/src/crr_sb_view.rs
@@ -390,6 +390,7 @@ impl CRRSBView {
                         chan_wire_stroke,
                         &chan_x_rect,
                         &sb_rect.size(),
+                        dark_mode,
                     );
                     channel_wires.append(&mut build_chan_y_shapes(
                         crr_sb,
@@ -397,6 +398,7 @@ impl CRRSBView {
                         chan_wire_stroke,
                         &chan_y_rect,
                         &sb_rect.size(),
+                        dark_mode,
                     ));
                     channel_wires_lookup.insert(csv_file_name.clone(), channel_wires);
 
@@ -405,6 +407,7 @@ impl CRRSBView {
                         spacing_between_points,
                         chan_wire_stroke,
                         &sb_rect,
+                        dark_mode,
                     );
                     segment_conns_lookup.insert(csv_file_name.clone(), segment_connections);
 
@@ -413,6 +416,7 @@ impl CRRSBView {
                         crr_sb_info,
                         spacing_between_points,
                         &sb_rect,
+                        dark_mode,
                     );
                     switch_conns_lookup.insert(csv_file_name.clone(), switch_connections);
                 }
@@ -545,6 +549,7 @@ impl CRRSBView {
                                     lb_render_tile,
                                     &tile_relative_offset,
                                     &sb_rect,
+                                    dark_mode,
                                 );
                                 for shape in &mut lb_connection_shapes {
                                     shape.translate(tile_offset.to_vec2());
@@ -819,7 +824,9 @@ fn build_chan_x_shapes(
     chan_wire_stroke: f32,
     chan_x_rect: &egui::Rect,
     sb_size: &egui::Vec2,
+    dark_mode: bool,
 ) -> Vec<egui::Shape> {
+    let wire_color = crate::color_scheme::crr_wire_color(dark_mode);
     let mut chan_x_shapes: Vec<egui::Shape> = Vec::with_capacity(crr_sb.chan_x_width);
     for chan_x_ptc in 0..crr_sb.chan_x_width {
         let left_conn_pt = get_ptc_loc(
@@ -833,7 +840,7 @@ fn build_chan_x_shapes(
                 left_conn_pt + chan_x_rect.left_top().to_vec2(),
                 left_conn_pt + chan_x_rect.right_top().to_vec2(),
             ],
-            egui::Stroke::new(chan_wire_stroke, egui::Color32::BLACK),
+            egui::Stroke::new(chan_wire_stroke, wire_color),
         ));
     }
 
@@ -846,7 +853,9 @@ fn build_chan_y_shapes(
     chan_wire_stroke: f32,
     chan_y_rect: &egui::Rect,
     sb_size: &egui::Vec2,
+    dark_mode: bool,
 ) -> Vec<egui::Shape> {
+    let wire_color = crate::color_scheme::crr_wire_color(dark_mode);
     let mut chan_y_shapes: Vec<egui::Shape> = Vec::with_capacity(crr_sb.chan_y_width);
     for chan_y_ptc in 0..crr_sb.chan_y_width {
         let left_conn_pt = get_ptc_loc(
@@ -860,7 +869,7 @@ fn build_chan_y_shapes(
                 left_conn_pt + chan_y_rect.left_top().to_vec2(),
                 left_conn_pt + chan_y_rect.left_bottom().to_vec2(),
             ],
-            egui::Stroke::new(chan_wire_stroke, egui::Color32::BLACK),
+            egui::Stroke::new(chan_wire_stroke, wire_color),
         ));
     }
 
@@ -872,7 +881,9 @@ fn build_segment_connection_shapes(
     spacing_between_points: f32,
     chan_wire_stroke: f32,
     sb_rect: &egui::Rect,
+    dark_mode: bool,
 ) -> Vec<egui::Shape> {
+    let wire_color = crate::color_scheme::crr_wire_color(dark_mode);
     let mut segment_connection_shapes: Vec<egui::Shape> = Vec::new();
     for chan_x_lane in &crr_sb.chan_x_lanes {
         for i in 0..(chan_x_lane.segment_len - 1) {
@@ -911,14 +922,14 @@ fn build_segment_connection_shapes(
                     left_source_loc + sb_rect.min.to_vec2(),
                     right_sink_loc + sb_rect.min.to_vec2(),
                 ],
-                egui::Stroke::new(chan_wire_stroke, egui::Color32::BLACK),
+                egui::Stroke::new(chan_wire_stroke, wire_color),
             ));
             segment_connection_shapes.push(egui::Shape::line_segment(
                 [
                     right_source_loc + sb_rect.min.to_vec2(),
                     left_sink_loc + sb_rect.min.to_vec2(),
                 ],
-                egui::Stroke::new(chan_wire_stroke, egui::Color32::BLACK),
+                egui::Stroke::new(chan_wire_stroke, wire_color),
             ));
         }
     }
@@ -959,14 +970,14 @@ fn build_segment_connection_shapes(
                     top_source_loc + sb_rect.min.to_vec2(),
                     bottom_sink_loc + sb_rect.min.to_vec2(),
                 ],
-                egui::Stroke::new(chan_wire_stroke, egui::Color32::BLACK),
+                egui::Stroke::new(chan_wire_stroke, wire_color),
             ));
             segment_connection_shapes.push(egui::Shape::line_segment(
                 [
                     bottom_source_loc + sb_rect.min.to_vec2(),
                     top_sink_loc + sb_rect.min.to_vec2(),
                 ],
-                egui::Stroke::new(chan_wire_stroke, egui::Color32::BLACK),
+                egui::Stroke::new(chan_wire_stroke, wire_color),
             ));
         }
     }
@@ -979,7 +990,9 @@ fn build_switch_connection_shapes(
     crr_sb_info: &CRRSwitchBlockDeserialized,
     spacing_between_points: f32,
     sb_rect: &egui::Rect,
+    dark_mode: bool,
 ) -> Vec<egui::Shape> {
+    let wire_color = crate::color_scheme::crr_wire_color(dark_mode);
     let mut switch_connection_shapes: Vec<egui::Shape> = Vec::new();
     for edge in &crr_sb_info.edges {
         let src_node = &crr_sb_info.source_nodes[edge.source_node_id];
@@ -1000,7 +1013,7 @@ fn build_switch_connection_shapes(
                 src_node_loc + sb_rect.min.to_vec2(),
                 sink_node_loc + sb_rect.min.to_vec2(),
             ],
-            egui::Stroke::new(1.0, egui::Color32::BLACK),
+            egui::Stroke::new(1.0, wire_color),
         ));
     }
 
@@ -1015,7 +1028,9 @@ fn build_lb_connection_shapes(
     logic_block_renderer: &TileRenderer,
     tile_relative_offset: &egui::Vec2,
     sb_rect: &egui::Rect,
+    dark_mode: bool,
 ) -> Vec<egui::Shape> {
+    let wire_color = crate::color_scheme::crr_wire_color(dark_mode);
     let mut lb_connection_shapes: Vec<egui::Shape> = Vec::new();
 
     // Draw flylines from pins to their connections.
@@ -1092,7 +1107,7 @@ fn build_lb_connection_shapes(
             for sink_node_loc in &sink_node_locs {
                 lb_connection_shapes.push(egui::Shape::line_segment(
                     [src_node_loc.to_pos2(), sink_node_loc.to_pos2()],
-                    egui::Stroke::new(1.0, egui::Color32::BLACK),
+                    egui::Stroke::new(1.0, wire_color),
                 ));
             }
         }

--- a/fpga_arch_viewer/src/grid_renderer.rs
+++ b/fpga_arch_viewer/src/grid_renderer.rs
@@ -52,7 +52,10 @@ impl GridRenderer {
                                 self.grid_shapes[die_id].push(egui::Shape::rect_stroke(
                                     rect,
                                     egui::CornerRadius::ZERO,
-                                    egui::Stroke::new(0.5, color_scheme::theme_border_color(dark_mode)),
+                                    egui::Stroke::new(
+                                        0.5,
+                                        color_scheme::theme_border_color(dark_mode),
+                                    ),
                                     egui::epaint::StrokeKind::Inside,
                                 ));
                             }

--- a/fpga_arch_viewer/src/grid_renderer.rs
+++ b/fpga_arch_viewer/src/grid_renderer.rs
@@ -1,4 +1,5 @@
 use crate::block_style::darken_color;
+use crate::color_scheme;
 use crate::grid::{DeviceGrid, GridCell};
 use crate::grid_view::GridState;
 use eframe::egui;
@@ -21,6 +22,7 @@ impl GridRenderer {
         grid: &DeviceGrid,
         tile_colors: &HashMap<String, egui::Color32>,
         zoom_factor: f32,
+        dark_mode: bool,
         ui: &egui::Ui,
     ) {
         self.grid_shapes.clear();
@@ -50,7 +52,7 @@ impl GridRenderer {
                                 self.grid_shapes[die_id].push(egui::Shape::rect_stroke(
                                     rect,
                                     egui::CornerRadius::ZERO,
-                                    egui::Stroke::new(0.5, egui::Color32::DARK_GRAY),
+                                    egui::Stroke::new(0.5, color_scheme::theme_border_color(dark_mode)),
                                     egui::epaint::StrokeKind::Inside,
                                 ));
                             }
@@ -75,7 +77,7 @@ impl GridRenderer {
                                 let color = tile_colors
                                     .get(pb_type)
                                     .copied()
-                                    .unwrap_or(egui::Color32::from_rgb(0xD8, 0xE7, 0xFD));
+                                    .unwrap_or(color_scheme::grid_lb_color(dark_mode));
 
                                 let outline_color = darken_color(color, 0.5);
 
@@ -107,7 +109,7 @@ impl GridRenderer {
                                             egui::Align2::CENTER_CENTER,
                                             &tile_name_upper,
                                             egui::FontId::proportional(font_size),
-                                            egui::Color32::BLACK,
+                                            color_scheme::theme_text_color(dark_mode),
                                         ));
                                     });
                                 }
@@ -150,6 +152,7 @@ impl GridRenderer {
         grid: &DeviceGrid,
         arch: &FPGAArch,
         state: &GridState,
+        dark_mode: bool,
     ) -> Option<String> {
         // Cell size is based on the available space
         let cell_size = get_cell_size(grid, state.zoom_factor, ui);
@@ -229,7 +232,7 @@ impl GridRenderer {
                             };
                             noc_shapes.push(egui::Shape::line_segment(
                                 [from_pos, to_pos],
-                                egui::Stroke::new(2.0, egui::Color32::BLACK),
+                                egui::Stroke::new(2.0, color_scheme::theme_text_color(dark_mode)),
                             ));
                         }
                     }
@@ -239,7 +242,7 @@ impl GridRenderer {
                         noc_shapes.push(egui::Shape::circle_filled(
                             *router_position,
                             cell_size / 2.0,
-                            egui::Color32::BLACK,
+                            color_scheme::theme_text_color(dark_mode),
                         ));
                     }
 

--- a/fpga_arch_viewer/src/grid_view.rs
+++ b/fpga_arch_viewer/src/grid_view.rs
@@ -89,24 +89,26 @@ pub struct GridView {
 
     // Renderer object in charge of the grid.
     pub grid_renderer: GridRenderer,
+
+    // Sorted tile names for rebuilding colors when dark mode changes.
+    sorted_tile_names: Vec<String>,
+    // Last dark mode value used to build tile_colors; None forces a rebuild.
+    last_dark_mode: Option<bool>,
 }
 
 impl GridView {
     pub fn on_architecture_load(&mut self, arch: &FPGAArch) {
-        // Extract unique tile names from all layouts
+        // Extract and store sorted unique tile names.
         let mut tile_names = std::collections::HashSet::new();
         for tile in &arch.tiles {
             tile_names.insert(tile.name.clone());
         }
+        self.sorted_tile_names = tile_names.into_iter().collect();
+        self.sorted_tile_names.sort();
 
-        // Assign colors to tile types
+        // Force a color rebuild on the next update_tile_colors call.
+        self.last_dark_mode = None;
         self.tile_colors.clear();
-        let mut sorted_tiles: Vec<_> = tile_names.into_iter().collect();
-        sorted_tiles.sort();
-        for (i, tile_name) in sorted_tiles.iter().enumerate() {
-            let color = crate::block_style::get_tile_color(tile_name, i);
-            self.tile_colors.insert(tile_name.clone(), color);
-        }
 
         // Reset layout selection and rebuild grid
         self.grid_state.selected_layout_index = 0;
@@ -114,17 +116,33 @@ impl GridView {
         self.rebuild_grid(arch);
     }
 
+    /// Rebuilds tile_colors for the given dark mode. Called every frame from
+    /// the top-level update so colors stay current regardless of active view.
+    pub fn update_tile_colors(&mut self, dark_mode: bool) {
+        if self.last_dark_mode == Some(dark_mode) {
+            return;
+        }
+        self.last_dark_mode = Some(dark_mode);
+        self.tile_colors.clear();
+        for (i, tile_name) in self.sorted_tile_names.iter().enumerate() {
+            let color = crate::block_style::get_tile_color(tile_name, i, dark_mode);
+            self.tile_colors.insert(tile_name.clone(), color);
+        }
+        self.grid_state.grid_changed = true;
+    }
+
     pub fn render(
         &mut self,
         arch: &FPGAArch,
         selected_tile_name: &mut Option<String>,
         next_view_mode: &mut ViewMode,
+        dark_mode: bool,
         ctx: &egui::Context,
     ) {
         self.render_side_panel(arch, ctx);
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            self.render_grid_view(arch, selected_tile_name, next_view_mode, ui);
+            self.render_grid_view(arch, selected_tile_name, next_view_mode, dark_mode, ui);
         });
 
         self.grid_state.zoom_changed = false;
@@ -172,6 +190,7 @@ impl GridView {
         arch: &FPGAArch,
         selected_tile_name: &mut Option<String>,
         next_view_mode: &mut ViewMode,
+        dark_mode: bool,
         ui: &mut egui::Ui,
     ) {
         // Handle zoom input (Cmd + scroll wheel or pinch gesture)
@@ -204,13 +223,14 @@ impl GridView {
                     grid,
                     &self.tile_colors,
                     self.grid_state.zoom_factor,
+                    dark_mode,
                     ui,
                 );
                 self.grid_state.last_available_size = current_available_size;
             }
             if let Some(clicked_tile) =
                 self.grid_renderer
-                    .render_grid(ui, grid, arch, &self.grid_state)
+                    .render_grid(ui, grid, arch, &self.grid_state, dark_mode)
             {
                 *selected_tile_name = Some(clicked_tile);
                 *next_view_mode = ViewMode::Tile;

--- a/fpga_arch_viewer/src/tile_rendering/tile_renderer.rs
+++ b/fpga_arch_viewer/src/tile_rendering/tile_renderer.rs
@@ -8,6 +8,7 @@
 use fpga_arch_parser::{PinSide, Tile};
 
 use crate::block_style;
+use crate::color_scheme;
 
 pub struct TileRenderer {
     /// The shapes that make up the logical block.
@@ -30,6 +31,7 @@ pub fn build_render_tile(
     tile: &Tile,
     tile_bounding_box: &egui::Rect,
     color: &egui::Color32,
+    dark_mode: bool,
 ) -> TileRenderer {
     // Build the logic block. For now its just a rectangle the size of the tile.
     let mut lb_shapes: Vec<egui::Shape> = Vec::new();
@@ -148,7 +150,7 @@ pub fn build_render_tile(
             pin_shapes.push(egui::Shape::circle_filled(
                 pin_pos.to_pos2(),
                 pin_radius,
-                egui::Color32::BLACK,
+                color_scheme::theme_text_color(dark_mode),
             ));
         }
     }

--- a/fpga_arch_viewer/src/tile_view.rs
+++ b/fpga_arch_viewer/src/tile_view.rs
@@ -4,7 +4,7 @@ use fpga_arch_parser::FPGAArch;
 use std::collections::HashMap;
 
 use crate::{
-    common_ui, complex_block_view::ComplexBlockViewState, intra_hierarchy_tree,
+    color_scheme, common_ui, complex_block_view::ComplexBlockViewState, intra_hierarchy_tree,
     tile_rendering::tile_renderer::build_render_tile, viewer::ViewMode,
 };
 
@@ -29,6 +29,7 @@ impl TileView {
         complex_block_view_state: &mut ComplexBlockViewState,
         next_view_mode: &mut ViewMode,
         tile_colors: &HashMap<String, egui::Color32>,
+        dark_mode: bool,
         ctx: &egui::Context,
     ) {
         egui::SidePanel::right("tile_view_controls")
@@ -47,6 +48,7 @@ impl TileView {
                 complex_block_view_state,
                 next_view_mode,
                 tile_colors,
+                dark_mode,
                 ui,
             );
         });
@@ -98,6 +100,7 @@ impl TileView {
         complex_block_view_state: &mut ComplexBlockViewState,
         next_view_mode: &mut ViewMode,
         tile_colors: &HashMap<String, egui::Color32>,
+        dark_mode: bool,
         ui: &mut egui::Ui,
     ) {
         match &self.selected_tile_name {
@@ -108,6 +111,7 @@ impl TileView {
                         complex_block_view_state,
                         next_view_mode,
                         tile_colors,
+                        dark_mode,
                         arch,
                         ui,
                     );
@@ -139,6 +143,7 @@ impl TileView {
         complex_block_view_state: &mut ComplexBlockViewState,
         next_view_mode: &mut ViewMode,
         tile_colors: &HashMap<String, egui::Color32>,
+        dark_mode: bool,
         arch: &FPGAArch,
         ui: &mut egui::Ui,
     ) {
@@ -187,8 +192,8 @@ impl TileView {
                     let color = tile_colors
                         .get(&tile.name)
                         .copied()
-                        .unwrap_or(egui::Color32::from_rgb(0xD8, 0xE7, 0xFD));
-                    let tile_renderer = build_render_tile(tile, &tile_bounding_box, &color);
+                        .unwrap_or(color_scheme::grid_lb_color(dark_mode));
+                    let tile_renderer = build_render_tile(tile, &tile_bounding_box, &color, dark_mode);
                     painter.extend(tile_renderer.lb_shapes);
                     painter.extend(tile_renderer.pin_shapes);
 

--- a/fpga_arch_viewer/src/tile_view.rs
+++ b/fpga_arch_viewer/src/tile_view.rs
@@ -193,7 +193,8 @@ impl TileView {
                         .get(&tile.name)
                         .copied()
                         .unwrap_or(color_scheme::grid_lb_color(dark_mode));
-                    let tile_renderer = build_render_tile(tile, &tile_bounding_box, &color, dark_mode);
+                    let tile_renderer =
+                        build_render_tile(tile, &tile_bounding_box, &color, dark_mode);
                     painter.extend(tile_renderer.lb_shapes);
                     painter.extend(tile_renderer.pin_shapes);
 

--- a/fpga_arch_viewer/src/viewer.rs
+++ b/fpga_arch_viewer/src/viewer.rs
@@ -498,6 +498,7 @@ impl FpgaViewer {
                     arch,
                     &mut self.tile_view.selected_tile_name,
                     &mut self.next_view_mode,
+                    self.viewer_ctx.dark_mode,
                     ctx,
                 ),
                 ViewMode::Tile => self.tile_view.render(
@@ -505,6 +506,7 @@ impl FpgaViewer {
                     &mut self.complex_block_view.complex_block_view_state,
                     &mut self.next_view_mode,
                     &self.grid_view.tile_colors,
+                    self.viewer_ctx.dark_mode,
                     ctx,
                 ),
                 ViewMode::ComplexBlock => self.complex_block_view.render(
@@ -516,7 +518,7 @@ impl FpgaViewer {
                 ViewMode::Primitive => self.primitive_view.render(arch, ctx),
                 ViewMode::CRRSwitchBlock => {
                     self.crr_sb_view
-                        .render(arch, &self.grid_view.tile_colors, ctx)
+                        .render(arch, &self.grid_view.tile_colors, self.viewer_ctx.dark_mode, ctx)
                 }
             },
             None => {
@@ -627,6 +629,7 @@ impl eframe::App for FpgaViewer {
         self.viewer_ctx
             .block_styles
             .update_colors(self.viewer_ctx.dark_mode);
+        self.grid_view.update_tile_colors(self.viewer_ctx.dark_mode);
 
         // Update FPS (smoothed with exponential moving average)
         let dt = ctx.input(|i| i.stable_dt);

--- a/fpga_arch_viewer/src/viewer.rs
+++ b/fpga_arch_viewer/src/viewer.rs
@@ -516,10 +516,12 @@ impl FpgaViewer {
                     ctx,
                 ),
                 ViewMode::Primitive => self.primitive_view.render(arch, ctx),
-                ViewMode::CRRSwitchBlock => {
-                    self.crr_sb_view
-                        .render(arch, &self.grid_view.tile_colors, self.viewer_ctx.dark_mode, ctx)
-                }
+                ViewMode::CRRSwitchBlock => self.crr_sb_view.render(
+                    arch,
+                    &self.grid_view.tile_colors,
+                    self.viewer_ctx.dark_mode,
+                    ctx,
+                ),
             },
             None => {
                 // If no architecture is loaded, no view can be seen, so show a welcome message.
@@ -626,11 +628,6 @@ impl eframe::App for FpgaViewer {
             self.viewer_ctx.window_title = desired_title;
         }
 
-        self.viewer_ctx
-            .block_styles
-            .update_colors(self.viewer_ctx.dark_mode);
-        self.grid_view.update_tile_colors(self.viewer_ctx.dark_mode);
-
         // Update FPS (smoothed with exponential moving average)
         let dt = ctx.input(|i| i.stable_dt);
         if dt > 0.0 {
@@ -645,6 +642,12 @@ impl eframe::App for FpgaViewer {
         // Render UI panels and windows
         self.render_menu_bar(ctx);
         self.render_navigation_buttons(ctx);
+
+        // Refresh colors after any menu action that may have loaded a new architecture.
+        self.viewer_ctx
+            .block_styles
+            .update_colors(self.viewer_ctx.dark_mode);
+        self.grid_view.update_tile_colors(self.viewer_ctx.dark_mode);
 
         // Render the page.
         self.render_page(ctx);


### PR DESCRIPTION
The dark mode was not working for the grid view or the tile view. Fixed it.

Resolves #116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark mode support with dynamically adapted color palettes throughout the viewer interface.
  * All visualization components, including tiles and grids, now automatically adjust styling based on the selected theme preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->